### PR TITLE
adapt error text 405, add latest hint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1285,7 +1285,7 @@ function checkRepo(context) {
                             context.checks.push('Icon found in latest repository');
 
                             if (!context.latestRepo[context.adapterName].icon.startsWith(url)) {
-                                context.errors.push(`[E405] Icon must be in the following path: ${url}`);
+                                context.errors.push(`[E405] Icon (latest) must be in the following path: ${url}`);
                             } else {
                                 context.checks.push('Icon found in latest repository');
                             }


### PR DESCRIPTION
Add (latest) info to E405 like (stable) is present at E428. This reduces the number of questions by user who are consused by searching io-package.json fro this error.