### PR TITLE
feat: add a generic credential checker for native keys

### DIFF
--- a/doc/issues.json
+++ b/doc/issues.json
@@ -461,6 +461,9 @@
   "W172": {
     "title": "`common.localLink` in io-package.json is deprecated. Please define object `common.localLinks`: { `_default`: `...` }"
   },
+  "W173": {
+    "title": "`native` contains a key that seems to be for sensitive data but does not have an entry in `protectedNative` nor in `encryptedNative`"
+  },
   "W302": {
     "title": "Use github actions instead of travis-ci"
   },


### PR DESCRIPTION
This checker is intended to identify native keys that contain potentially sensitive information but are neither protected from access by other adapters (have no entry in protectedNative) nor stored in encrypted form (encryptedNative).

The pattern list is based on the example of gitleaks for generic credentials (see also https://github.com/gitleaks/gitleaks/blob/6c52f878cc48a513849900a9aa6f9d68e1c2dbdd/cmd/generate/config/rules/generic.go#L12) and is not particularly restrictive in order to generate as few false positives as possible. Feel free to even prune this list a little further :)

In my opinion this is a good heuristic and non invasive way to point to possible security smells.