### PR TITLE
fix: resolve TypeError in local mode and add exit code on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,39 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+
+- (@copilot) Fixed `GLOBAL ERROR: TypeError: Cannot read properties of undefined (reading 'includes')` in `checkCode` when running in local mode (`--local`).
+- (@copilot) CLI now exits with code `1` when errors are found, enabling use in command chains like `npx @iobroker/repochecker repo --local && npm run release`.
+
 ### 5.11.1 (2026-04-25)
+
 - (@ticaki) Local mode has been fixed.
 
 ### 5.11.0 (2026-04-21)
+
 - (@copilot) Added `[W2007]`: warn when the npm `latest` dist-tag points to an alpha/pre-release version, as such releases will be ignored by repository updates.
 - (@copilot) Added `lib/postprocessing.js` module: new adapters (where `isNewAdapter` is set) now have selected warnings and suggestions promoted to errors or warnings according to a configurable severity-remap table, making the checker stricter for new adapter submissions.
 - (@copilot) Fixed adapter detection to ensure the `isNewAdapter` flag is set before configuration logging. Added a new `getLatestRepo` preprocessing step so that the flag is correctly visible in the environment log output.
 - (@copilot) Added German translation of OBJECTDUMP.md as OBJECTDUMP_de.md.
 
 ### 5.10.4 (2026-04-12)
+
 - (@copilot) Enhanced E6013 check: detects additional discouraged installation methods in README.md, including `iobroker`/`iob` npm install and url commands, and `npm install`/`npm i` with `owner/iobroker.adaptername` GitHub shorthand. Updated error message to mention "directly from GitHub, directly from npm or using npm commands".
 
 ### 5.10.3 (2026-04-11)
+
 - (@copilot) Fixed false positive W5042 for TypeScript type-only imports: `import type { Foo } from 'pkg'` no longer registers `pkg` as a required runtime dependency. Related to [#833]
 
 ### 5.10.2 (2026-04-11)
+
 - (@copilot) Fixed false positive `[E9507]` for i18n directories inside source directories (`src-rules`, `rules-src`, `src-editor`, `src-widgets`, `admin/src`, etc.) by expanding the ignored source directory list and checking the full parent path instead of only the top-level segment. Related to [#828].
 - (@copilot) Added adapter-specific exceptions to E0050 blacklist: `@iobroker/plugin-sentry` is now allowed as a dependency for `ioBroker.javascript`.
 - (@copilot) Added system-provided packages ignore list for W5042: `@iobroker/plugin-sentry` will no longer raise "dependency might be missing" warnings as it is provided by js-controller.
 
 ### 5.10.1 (2026-04-10)
+
 - (@copilot) Fixed `TypeError: minimatch is not a function` in `checkNpmIgnore` by correctly destructuring `minimatch` from the `minimatch` v10+ package export.
 - (@copilot) Added `minimatch` as an explicit dependency in `package.json` (used by `M9000_GitNpmIgnore.js` for glob pattern matching).
 - (@copilot) Fixed false positives in `[E9507]` when i18n directories are covered by glob patterns in `package.json` `"files"` field.
@@ -54,23 +66,28 @@ Example:
 - (@copilot) Added `[E9507]`: error when an i18n directory is present in the repository but not covered by the `"files"` field in `package.json`, which would cause translations to be missing from the npm package.
 
 ### 5.9.1 (2026-04-08)
+
 - (@copilot) Added `isNewAdapter` flag: set to `true` when adapter is not listed in the latest repository, with an info log when set.
 - (@copilot) Added `--strict` command line option: when active, outputs an info log "running in strict mode".
 - (@copilot) `[S6020]` suggestion to add `CHANGELOG_OLD.md` is now only shown when `isNewAdapter` is set or strict mode is active.
 
 ### 5.9.0 (2026-04-08)
+
 - (@copilot) Added checks W1114/S1114: warn when `common.schedule` is set to a non-empty value for daemon adapters (not supported), and suggest removal when `common.schedule` is an empty string for daemon adapters (unused). Related to [#806].
 - (@copilot) Added checks to help maintain organized changelog files: warns when CHANGELOG.md is present (changelog belongs in README.md), when both CHANGELOG.md and CHANGELOG_OLD.md coexist, when the README changelog exceeds 20 entries without a CHANGELOG_OLD.md, and suggests adding CHANGELOG_OLD.md when no such file exists. [W6017, W6018, W6019, S6020]
 
 ### 5.8.0 (2026-04-07)
+
 - (@copilot) Limit the listing of `allowedValues` in schema validation errors (E1105, W5512) to 5 values, appending `...` when there are more possibilities.
 - (@copilot) [W5046] Added warning when `admin/jsonConfig.json` or `admin/jsonConfig.json5` is present but `common.adminUI.config` is not set to `"json"` in `io-package.json`.
 - (@copilot) [W5047] Added warning listing obsolete files (`admin/index.html`, `admin/index_m.html`, `admin/style.css`) when jsonConfig is used.
 
 ### 5.7.1 (2026-04-07)
+
 - (mcm1957) Improve jsonConfig schema validation messages.
 
 ### 5.7.0 (2026-04-06)
+
 - (@copilot) [S8913] automerge suggestion is no longer shown when dependabot is not configured ([S8901]).
 - (@copilot) Language detection: `GERMAN_WORDS` and `ENGLISH_WORDS` arrays sorted alphabetically; chapters titled "Haftungsausschluss" in README.md are now ignored when checking for German text.
 - (@copilot) Added [W8915]: warn when a dependabot npm entry has no cooldown or a cooldown of less than 5 days configured, recommending at least 7 days to reduce supply chain risk.
@@ -79,18 +96,23 @@ Example:
 - (@copilot) Added schema validation for all present jsonConfig files (`admin/jsonConfig.json`, `admin/jsonCustom.json`, `admin/jsonTab.json` and their `.json5` variants) against the official jsonConfig JSON schema; errors reported as E5512, schema download failures as W5513, and exceptions as E5514. [#803]
 
 ### 5.6.9 (2026-04-02)
+
 - (mcm1957) Ignore "widgets" directory when scanning for imported packages.
 
 ### 5.6.7 (2026-04-02)
+
 - (@copilot) Fixed false positive package detection in `extractImports`: dynamic imports like `import("pkg")` no longer incorrectly trigger the `import ... from ...` pattern, preventing values in log strings (e.g. `from 'force_full'`) from being mistaken for package names.
 
 ### 5.6.6 (2026-03-29)
+
 - (mcm1957) Severity for [S3010] has been corrected.
 
 ### 5.6.5 (2026-03-27)
+
 - (@copilot) Exclude `gulpfile.js` and `lib/tools.js` from W5042/S5043 dependency scanning; added easy-to-extend `excludedSourceFiles` and `excludedSourceRelPaths` Sets for future exclusions.
 
 ### 5.6.2 (2026-03-27)
+
 - (@copilot) Suppress unwanted npm E404 error output when checking adapters that are not published on npm.
 - (@copilot) Added E2006 error when an npm package has no published versions available, instead of silently skipping version checks.
 - (@copilot) Handle unpublished npm packages: detect "Unpublished on ..." response from npm registry and report a specific E2000 error instead of the generic "not found" message; suppress raw npm error logs for unpublished packages in README/LICENSE year checks. [#766]
@@ -98,20 +120,25 @@ Example:
 - (@copilot) Added W5042 and S5043 checks: source files (`*.js`, `*.mjs`, `*.cjs`, `*.ts`) are now scanned for `require`/`import` statements (excluding `admin/`, `doc/`, `src-admin/`, `test/` directories and `*.test.*`/`*.config.*` files). W5042 warns when an imported package is not listed in `dependencies` of `package.json`. S5043 suggests using the `node:` prefix when importing known Node.js built-in modules without it.
 
 ### 5.5.5 (2026-03-24)
+
 - (mcm1957) remove '[S6014] README.md section "## Installation" should be removed unless the adapter requires special installation handling.'
 
 ### 5.5.4 (2026-03-22)
+
 - (@copilot) Fixed E6015/W6016 false positives: German (and English) language detection now ignores fenced code blocks, inline code, blockquote lines, link URLs, and image markup before analyzing the README text.
 
 ### 5.5.3 (2026-03-19)
+
 - (@copilot) Fixed E3016 false positive: transitive `needs` dependencies are now considered, so `deploy` depending on `adapter-tests` which already depends on `check-and-lint` is correctly accepted. Related to [#756].
 - (@copilot) W5041 warning now includes the list of languages that contain the example keys (e.g. `languages: en, de, ru`).
 
 ### 5.5.2 (2026-03-17)
+
 - (@copilot) E5040 and W5041 messages now include the specific detected key(s) (e.g. `option1`, `option2`, or both) instead of the generic `option1/option2` placeholder. Only one issue is raised even when multiple keys are detected.
 - (@copilot) Fixed E1111/W1111 checks: E1111 and W1111 are now renamed to E5040 and W5041 (correct numbering range for M5000_Code module). Both checks now correctly exempt adapters where `option1`/`option2` keys are genuinely used in `admin/index.html`, `admin/index_m.html`, or as keys in `admin/jsonConfig.json`/`admin/jsonConfig.json5`. Related to [#746].
 
 ### 5.5.1 (2026-03-17)
+
 - (@copilot) Added W5039 check: warns when `admin/words.js` exists but is not referenced anywhere in the codebase for adapters using jsonConfig. The file seems to be outdated and should be removed [#745].
 - (@copilot) Added W3018 and W3019 checks: when deploy job uses `ioBroker/testing-action-deploy@v1`, warns if job-level permissions (`contents: write`, `id-token: write`) are missing (W3018) or if the `npm-token` parameter is specified (W3019), as trusted publishing will not work in either case. Related to [#742].
 - (@copilot) Added W1113 check: warns when `native` config object contains properties but `common.adminUI.config` is set to `"none"`, as the native config will not be used without an admin UI config.
@@ -126,12 +153,15 @@ Example:
 - (@copilot) Extended E6013 check: now also triggers on "Install the adapter via ioBroker Admin as a ZIP file" and "Install from own URL" phrases (case-insensitive). Related to [#727].
 
 ### 5.4.1 (2026-03-13)
+
 - (mcm197) E3008 has been fixed
 
 ### 5.4.0 (2026-03-11)
+
 - (@copilot) OnlyWWW adapters no longer require testing dependencies or adapter test workflows (skips E3000, E3011, and W3015 checks for adapters with `common.onlyWWW = true`).
 
 ### 5.3.0 (2026-03-11)
+
 - (@copilot) Added validation for dependabot configuration: checks for required ecosystems (github-actions, npm), schedule settings, open-pull-requests-limit, and automerge workflow configuration (checks S8901–S8914).
 - (@copilot) Extended W5034 check to also warn when `.ts` and `.js`/`.cjs`/`.mjs` versions of the same file exist in the same directory.
 - (@copilot) E3003 YAML parse error for workflow files now logs only the first line (without the file excerpt).
@@ -139,25 +169,29 @@ Example:
 - (@copilot) Extended testing checks (M3000_Testing.js): added checks for testing devDependency, test-and-release.yml workflow file presence, validity and required configuration.
 
 ### 5.2.3 (2026-02-26)
+
 - (@copilot) Fixed crash when `devDependencies` is missing from package.json. [#675]
 
 ### 5.2.2 (2026-02-25)
+
 - (mcm1957) Add warning if fa-icon entry still exists.
 - (@copilot) Added W6011/W7004 checks: warn when copyright lines in README.md or LICENSE are separated by an empty line instead of trailing two spaces.
 - (@copilot) Fixed false positive W6009/W7003: warning for non-consecutive copyright lines (separated by other text or empty lines) is no longer issued. [#672]
 - (@copilot) Fixed false positive S0048/S0047 for npm alias dependencies (e.g. `"npm:real-package@^1.2.3"`). [#667]
 - (@copilot) Added jsonConfig components `iframe` and `iframeSendTo` with minAdmin 7.7.28.
 - (@copilot) Added jsonConfig component `yamlEditor` with minAdmin 7.7.31. [#660]
-- (@copilot) Restructured `validComponents` entries in M5500__JsonConfig.js to objects with `function` and `minAdmin` properties.
+- (@copilot) Restructured `validComponents` entries in M5500\_\_JsonConfig.js to objects with `function` and `minAdmin` properties.
 - (@copilot) Added `checkDocker` and `infoBox` as known jsonConfig components to fix false-positive E5504 errors; set minAdmin 7.7.31 for `checkDocker`. [#663]
 - (mcm1957) require js-controlelr 6 and admin 7 now. [#641] [#589]
 - (mcm1957) required and suggested releases of standard packages have been updated.
 - (mcm1957) Dependencies to packages named 'admin' and 'iobroker' have been disallowed. [#617]
 
 ### 5.1.1 (2025-12-01)
+
 - (@copilot) Updated repository URLs from http://repo.iobroker.live to https://download.iobroker.net
 
 ### 5.1.0 (2025-11-25)
+
 - (@copilot) Added check for conflicting JSON/JSON5 files with same base name in same directory (E5038) [#169]
 - (@copilot) Added .releaseconfig.json verification to check plugins listed match installed devDependencies (E5036, W5037)
 - (@copilot) Added YAML file validation check (E5035) to verify .yml and .yaml files are well-structured [#618]
@@ -170,12 +204,15 @@ Example:
 - (mcm1957) Pathc information has been added to error E5509. [#394]
 
 ### 5.0.2 (2025-10-03)
+
 - (mcm1957) Some debug log has been removed.
 
 ### 5.0.1 (2025-10-03)
+
 - (mcm1957) A crash at adapters which do not contain news entry at io-package.json has been fixed. [#572]
 
 ### 5.0.0 (2025-10-02)
+
 - (mcm1957) Suppress W6010 if adapter not yet published at npm. [#567]
 - (@copilot) Added check for deprecated common.jsonConfig property - warns if adminUI exists (W1109), errors if adminUI missing (E1109)
 - (@copilot) Added check (W0063) for unneeded devDependencies when @iobroker/testing >= 5.1.1 is installed
@@ -200,6 +237,7 @@ Example:
 - (@copilot) Fixed deprecated function checking for adapter methods called outside class context
 
 ### 4.2.0 (2025-09-20)
+
 - (mcm1957) 'Request' replacement text changed to suggest 'node:fetch' [#498].
 - (@copilot) Fixed false positive W533 warnings for deprecated adapter methods when called on local functions with same names [#520].
 - (mcm1957) '[W438] .vscode/settings.json file missing "json.schemas" property' has been converted to suggestion [#516].
@@ -209,7 +247,7 @@ Example:
 - (copilot) Added check for outdated lib/tools.js file usage (W532) [#432].
 - (copilot) Added VS Code schema definitions checker for .vscode/settings.json - validates json.schemas for io-package.json and jsonConfig files [#336].
 - (copilot) Change W510 to E510: Convert missing admin i18n files from warning to error [#400].
-- (copilot) Renumbered all issues in M500__JsonConfig.js from 500-511 range to 550-561 range [#481].
+- (copilot) Renumbered all issues in M500\_\_JsonConfig.js from 500-511 range to 550-561 range [#481].
 - (copilot) Added check for .commitinfo file - error if present (E905), warning if not in .gitignore (W906) [#467].
 - (copilot) Added check for allowInit attribute [#181].
 - (copilot) Added detection for empty dependency objects in io-package.json (E200, E201) [#422].
@@ -218,6 +256,7 @@ Example:
 - (copilot) Fixed W195 warning for array elements - add W203 warning for unsupported array encryption [#399].
 
 ### 4.1.0 (2025-09-11)
+
 - (mcm1957) eslint-config and testing suggestions have been updated.
 - (mcm1957) adapter-core suggestions has been updated.
 - (mcm1957) URGENT and IMPORTANT issued are watched now.
@@ -226,13 +265,15 @@ Example:
 - (mcm1957) Text for S191 has been extended [#393].
 - (mcm1957) Text for S052 has been corrected [#434].
 - (mcm1957) Formatting if W174 has been improved [#408].
-- (mcm1957) @types/* as dependency now raise a warning [#421].
+- (mcm1957) @types/\* as dependency now raise a warning [#421].
 - (mcm1957) Dependencies have been updated.
 
 ### 4.0.2 (2025-08-12)
+
 - (mcm1957) js-controller 6.0.11 recommended now.
 
 ### 4.0.1 (2025-08-11)
+
 - (mcm1957) Wrong suggestion to add admin dependency has been corrected [#452].
 - (mcm1957) Text for E952 has been corrected [#446].
 - (mcm1957) Adapt wording at W098 / E029 [#448].
@@ -241,30 +282,37 @@ Example:
 - (mcm1957) jsonConfig expertMode flag added [#386].
 
 ### 4.0.0 (2025-08-05)
+
 - (mcm1957) use jsdelivr.com to retrive files from github.
 - (mcm1957) Dependencies have been updated.
 
 ### 3.5.8 (2025-05-17)
+
 - (mcm1957) add authorization for github using OWN_GITHUB_TOKEN.
 
 ### 3.5.5 (2025-04-28)
+
 - (mcm1957) Node.js 20 is suggested now.
 - (mcm1957) Suggested release for several packages has been encreased.
 - (mcm1957) Do not raise E186 if E190 is raised anyway. [#387]
 - (mcm1957) Dependencies have been updated.0
 
 ### 3.5.4 (2025-03-03)
+
 - (mcm1957) Ignore boolean paramters when checking protectedNative/encryptedNative. [#395]
 
 ### 3.5.3 (2025-02-21)
+
 - (mcm1957) Crash has been fixed if protectedNative/encryptedNative is not an array. [#385]
 
 ### 3.5.2 (2025-02-19)
+
 - (mcm1957) Incorrect admin suggestion for very olf html adapters corrected. [#383]
 - (mcm1957) Errors during parsing if icon improved. [#381]
 - (mcm1957) Crash if protectedNative or encryptedNative is missing. [#382]
 
 ### 3.5.0 (2025-02-18)
+
 - (mcm1957) Fixed dependency warning ([W174]) has been reduces to suggestion. [#374]
 - (mcm1957) Some changes to jsonConfig check have been implemented.
 - (mcm1957) common.supportCustoms check has been added. [#379]
@@ -272,21 +320,25 @@ Example:
 - (mcm1957) Check that key listed at encryptedNative is listed at protectedNative too. [#342]
 - (mcm1957) Check that extension adapters require web adapter. [#311]
 - (mcm1957) List of suspicious keys to protect has been extended. [#358]
-- (mcm1957) checking of 'admin'  globalDependency has been added.
+- (mcm1957) checking of 'admin' globalDependency has been added.
 - (mcm1957) checking of 'publishConfig.registry' has been added.
 - (mcm1957) New commandline option --noinfo added.
 - (mcm1957) Logging has been adapted.
 
 ### 3.4.4 (2025-02-12)
+
 - (mcm1957) Some external attributes added to valid package.json attributes.
 
 ### 3.4.2 (2025-02-12)
+
 - (mcm1957) 'type' and 'types' added to valid package.json attributes.
 
 ### 3.4.1 (2025-02-11)
+
 - (mcm1957) Add 'publishConfig' to valid package.json attributes.
 
 ### 3.4.0 (2025-02-11)
+
 - (mcm1957) Do not suggest to migrate to adapter-dev if only gulpfile.js exists. (#334).
 - (mcm1957) Warn if onlyWWW adapter uses adapter-core (#251).
 - (mcm1957) Singleton checks have been reduced to suggestion level.
@@ -303,12 +355,15 @@ Example:
 - (mcm1957) Adapt copyright year advisory.
 
 ### 3.3.2 (2025-01-20)
+
 - (mcm1957) Avoid crash if some file cannot be downloaded.
 
 ### 3.3.1 (2025-01-19)
+
 - (mcm1957) Report malformed semver specifications has been fixed.
 
 ### 3.3.0 (2025-01-19)
+
 - (mcm1957) "common.singleton" causes a warning now for non-onlyWWW Adapters.
 - (mcm1957) "$schema" has been blacklisted at io-package.json.
 - (mcm1957) Warn if 'common.nondeletable' flag is detected.
@@ -319,27 +374,33 @@ Example:
 - (mcm1957) Releaseinfo has been added to "checks" log.
 
 ### 3.2.4 (2025-01-16)
+
 - (mcm1957) Suggested release of testing and adapter-core increased.
 
 ### 3.2.3 (2025-01-11)
+
 - (mcm1957) An error is issued if js-controller dependency is missing.
 - (mcm1957) Required js-controller has been increased to 5.0.19.
 - (mcm1957) Recommended js-controller version is omitted if identical to required one.
 
 ### 3.2.2 (2024-11-01)
+
 - (mcm1957) Link to open issues has been corrected.
 - (mcm1957) Component name added to responsive check issues.
 
 ### 3.2.1 (2024-11-01)
+
 - (mcm1957) Size checking for "divider" and "staticImage" suspended.
 
 ### 3.2.0 (2024-11-01)
+
 - (oweitman) Script has been extended to use optionally local data for checking.
 - (mcm1957) Warning if i18n is not used has been fixed [#324].
 - (mcm1957) Check for importent issues has been added.
 - (mcm1957) Checking of jsonConfig (initially) added.
 
 ### 3.1.4 (2024-10-26)
+
 - (mcm1957) linter has been activated and issues reported have been fixed.
 - (mcm1957) Blacklist for package/dependencies has been extended.
 - (mcm1957) Recommend adapter-core 3.2.2 now.
@@ -347,12 +408,15 @@ Example:
 - (mcm1957) Abort processing if iobroker.live not reachable. [#321]
 
 ### 3.1.3 (2024-10-11)
+
 - (mcm1957) Checker no longer crash id no npm package exists.
 
 ### 3.1.2 (2024-10-04)
+
 - (mcm1957) Require node 18 minimum as engines clause.
 
 ### 3.1.1 (2024-10-04)
+
 - (mcm1957) "[E166] 'common.mode: extension' is unknown" has been fixed [#308]
 - (mcm1957) "[E904] file iob_npm.done found in repository, but not found in .gitignore" removed as covered by [E503]. [#309]
 - (mcm1957) "[E500] node_modules found" has been retricted to adapetr root. [#297]
@@ -360,22 +424,27 @@ Example:
 - (mcm1957) Change "[W113] Adapter should support compact mode" text and honor common.compact set to false. [#300]
 
 ### 3.1.0 (2024-09-29)
+
 - (mcm1957) "@iobroker/plugin-sentry" blacklisted as dependency [#301]
 - (mcm1957) Accept .ts files as main file too. [#303]
 - (mcm1957) [E405] and [E426] incorrect path has been corrected. [#299]
 
 ### 3.0.7 (2024-09-19)
+
 - (mcm1957) "[W523] 'package-lock.json"'not found in repo!" reduced to suggestion. [#298]
 
 ### 3.0.6 (2024-09-13)
+
 - (mcm1957) "[E124] Main file not found" no longer raised if `common.nogit` is set
 - (mcm1957) 'Text of "common.main" is deprecated' has been adapted. [#266]
 - (mcm1957) Ignore errors caused by complex .gitignor/.npmignore. [#288]
 
 ### 3.0.5 (2024-09-13)
+
 - (mcm1957) '@iobroker/dev-server' is valid as dev-dependency. [#260]
 
 ### 3.0.4 (2024-09-12)
+
 - (mcm1957) Abort with incorrect dependency definition fixed [#287]
 - (mcm1957) Improve handling of malformed dependency definitions [#284]
 - (mcm1957) Improve handling of malformed .releaseconfig.json files [#283]
@@ -385,28 +454,34 @@ Example:
 - (mcm1957) Do no longer require a js-controller dependency for wwwOnly adapters. [#250]
 
 ### 3.0.3 (2024-09-12)
+
 - (mcm1957) Check for iob_npm.done at `.npmignore` has been removed [#294]
 
 ### 3.0.2 (2024-09-11)
+
 - (mcm1957) Handling of a missing LICENSE file corrected. [#282]
 - (mcm1957) [W126] Missing mandatory translation is an error now. [#293]
 - (mcm1957) Record repochcker version used for tests.
 - (mcm1957) Record GitHub commit-sha of last commit used for tests.
 
 ### 3.0.0 (2024-09-10)
+
 - (mcm1957) Error and warning numbering has been reviewed and duplicates removed.
 - (mcm1957) index.js has been split into seperated modules.
 
 ### 2.10.0 (2024-08-19)
+
 - (mcm1957) Suggestions ([Sxxx] have been added).
 
 ### 2.9.1 (2024-08-12)
+
 - (mcm1957) E162 - correct dependency check for js-controller. [#267].
 - (mcm1957) E605 - copyright year range including whitespaces is now accepted. [#269].
 - (mcm1957) E016 - missing vaiable expansion has been added. [#263].
 - (mcm1957) E114 - typo at error message has been fixed [#261].
 
 ### 2.9.0 (2024-07-29)
+
 - (mcm1957) Adapt text if sources-dist(-stable).json need a correction [#97].
 - (mcm1957) Missing "common.mode" error text corrected [#249].
 - (mcm1957) Files "iob" and "iobroker" are disallowed now [#248].
@@ -414,10 +489,12 @@ Example:
 - (mcm1957) Text of E114 (missing adminUI) adapted.
 
 ### 2.8.1 (2024-07-28)
+
 - (mcm1957) Check of js-controller version has been corrected [#247].
 - (mcm1957) Honor '>' at dependency checks too [#246].
 
 ### 2.8.0 (2024-07-28)
+
 - (mcm1957) Copyright year check has been fixed for single year entries.
 - (mcm1957) js-controller version check added [#233].
 - (mcm1957) Check for fixed version dependencies and for github dependencies [#233].
@@ -427,12 +504,15 @@ Example:
 - (mcm1957) "common.noConfig" must match "common.adminUI" setting [#170].
 
 ### 2.7.2 (2024-07-26)
+
 - (mcm1957) package-lock.json check fixed.
 
 ### 2.7.1 (2024-07-26)
+
 - (mcm1957) Reduce setTimeout/setInterval error to warning temporary.
 
 ### 2.7.0 (2024-07-26)
+
 - (mcm1957) Some non trivial keywords related to adapter are enforced now [#234].
 - (mcm1957) Severity if [E105] / [W105] has been corrected [#204].
 - (mcm1957) Disallow 'globalDependencies' at package.json [#204].
@@ -446,29 +526,36 @@ Example:
 - (mcm1957) Copyright year now honors commit year and npm publish year too [#237].
 
 ### 2.6.1 (2024-06-24)
+
 - (mcm1957) Check "[W156] Adapter should support admin 5 UI (jsonConfig)" checks for reactUi now.
 
 ### 2.6.0 (2024-06-24)
+
 - (mcm1957) Check has been aded to ensure keywords and common.keywords are present. [#200]
 - (mcm1957) Detection of react has been added, gulpfile.js is accepted for react based UIs now. [#223]
 
 ### 2.5.1 (2024-06-24)
+
 - (mcm1957) Suggestion to update dependencies to recommended version added.
 - (mcm1957) Adapter-core recommended set to 3.1.6 [#220]
 
 ### 2.5.0 (2024-05-30)
+
 - (mcm1957) Check to ensure that dependency revisions are available at repository added. [#180]
 
 ### 2.4.0 (2024-05-30)
+
 - (mcm1957) Add check to protect sensitive data. [#195]
 - (mcm1957) Add check to verify that dependencies and globalDepencies are of type array. [#90]
 
 ### 2.3.1 (2024-05-07)
+
 - (mcm1957) Reduce number of missing translation warnings.
 - (mcm1957) Seperate between required and recommended translations.
 - (mcm1957) Log missing translations in detail.
 
 ### 2.3.0 (2024-05-07)
+
 - (mcm1957) Elements marked as deprectaed added to blacklist.
 - (mcm1957) Blacklist added to block elements at package.json and io-package.json.
 - (mcm1957) Error [E000] will be raised now if repository cannot be accessed at all [#194].
@@ -477,13 +564,16 @@ Example:
 - (mcm1957) Raise an error if version at package.json is lower than latest release at npmjs [#192]
 
 ### 2.2.3 (2024-03-29)
+
 - (mcm1957) Checking of license has been improved
 
 ### 2.2.2 (2024-03-29)
+
 - (mcm1957) Checking of adapter-core has been fixed
 - (mcm1957) Load all potential interesting files, fixes [#149]
 
 ### 2.2.1 (2024-03-26)
+
 - (mcm1957) Added check that own adapter is not listed at common.restartAdapters
 - (mcm1957) Added check of version strings at common.news
 - (mcm1957) Added check for recommended node version (node 18 for now)
@@ -492,40 +582,51 @@ Example:
 - (mcm1957) Added check for adapter-core version (>= 3.0.6)
 
 ### 2.2.0 (2024-03-24)
+
 - (klein0r) Added check for licenseInformation
 - (klein0r) Added check for deprecated license
 - (klein0r) Added check for required attribute common.tier
 - (klein0r) Added check for disallowed attribute common.automaticUpgrade
 
 ### 2.1.13 (2024-01-02)
+
 - (bluefox) Corrected rule W156: adminUI.config === 'none' is allowed
 
 ### 2.1.12 (2023-09-21)
+
 - (bluefox) Added check of using '\_' in adapter name
 
 ### 2.1.11 (2023-09-05)
+
 - (bluefox) Added check of iobroker.js-controller in dependencies
 
 ### 2.1.7 (2023-08-14)
+
 - (mcm57) Update index.js - fix typo in error message (packet.json)
 - (mcm57) Update index.js - renumber E504/1 to 519 - fixes #112
 
 ### 2.1.6 (2022-12-08)
+
 - (bluefox) added better error logging
 
 ### 2.1.5 (2022-12-07)
+
 - (bluefox) added check of `.releaseconfig.json` file
 
 ### 2.1.4 (2022-08-19)
+
 - (bluefox) Added check for adapter name: it may not start with '\_'
 
 ### 2.1.2 (2022-07-14)
+
 - (bluefox) Fixed some errors
 
 ### 2.1.0 (2022-05-26)
+
 - (bluefox) Added support for jsonConfig.json5 and jsonCustom.json5
 
 ### 2.0.5 (2022-05-22)
+
 - (bluefox) Made it possible to run with npx
 
 ## License
@@ -550,6 +651,5 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-
 
 THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ const postprocessing = require('./lib/postprocessing.js');
 // 9000 - 9998
 //      check .gitignore file
 
-function getGithubApiData(context) {
+function getGithubApiData (context) {
     return new Promise((resolve, reject) => {
         common.debug('getGithubApiData');
         common.debug(`reading url '${context.githubUrlApi}'`);
@@ -99,7 +99,7 @@ function getGithubApiData(context) {
     });
 }
 
-function makeResponse(code, data) {
+function makeResponse (code, data) {
     return {
         statusCode: code || 200,
         headers: {
@@ -110,7 +110,7 @@ function makeResponse(code, data) {
     };
 }
 
-function check(request, ctx, callback) {
+function check (request, ctx, callback) {
     //    console.log('PROCESS: ' + JSON.stringify(request));
     console.log('');
 
@@ -249,7 +249,7 @@ if (typeof module !== 'undefined' && module.parent) {
 
     // Get url from parameters if possible
     if (process.argv.length > 2) {
-        repoUrl = process.argv[2];
+        repoUrl = process.argv[ 2 ];
 
         if (!repoUrl.toLowerCase().includes('github.com')) {
             repoUrl = `https://github.com/${repoUrl}`;
@@ -261,7 +261,7 @@ if (typeof module !== 'undefined' && module.parent) {
 
     // Get branch from parameters if possible
     if (process.argv.length > 3) {
-        repoBranch = process.argv[3];
+        repoBranch = process.argv[ 3 ];
     }
 
     common.info(`Checking repository ${repoUrl} (branch ${repoBranch})`);
@@ -338,6 +338,10 @@ if (typeof module !== 'undefined' && module.parent) {
                 console.log('\n\nNO suggestions encountered.');
             }
             console.log(`\ncreated by repochecker ${context.version} based on commit ${context.lastCommitSha}`);
+
+            if (context.errors.length) {
+                process.exit(1);
+            }
         },
     );
 }

--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ if (typeof module !== 'undefined' && module.parent) {
             }
             console.log(`\ncreated by repochecker ${context.version} based on commit ${context.lastCommitSha}`);
 
-            if (context.errors.length) {
+            if (common.isLocal() && context.errors.length) {
                 process.exit(1);
             }
         },

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ const postprocessing = require('./lib/postprocessing.js');
 // 9000 - 9998
 //      check .gitignore file
 
-function getGithubApiData (context) {
+function getGithubApiData(context) {
     return new Promise((resolve, reject) => {
         common.debug('getGithubApiData');
         common.debug(`reading url '${context.githubUrlApi}'`);
@@ -99,7 +99,7 @@ function getGithubApiData (context) {
     });
 }
 
-function makeResponse (code, data) {
+function makeResponse(code, data) {
     return {
         statusCode: code || 200,
         headers: {
@@ -110,7 +110,7 @@ function makeResponse (code, data) {
     };
 }
 
-function check (request, ctx, callback) {
+function check(request, ctx, callback) {
     //    console.log('PROCESS: ' + JSON.stringify(request));
     console.log('');
 
@@ -249,7 +249,7 @@ if (typeof module !== 'undefined' && module.parent) {
 
     // Get url from parameters if possible
     if (process.argv.length > 2) {
-        repoUrl = process.argv[ 2 ];
+        repoUrl = process.argv[2];
 
         if (!repoUrl.toLowerCase().includes('github.com')) {
             repoUrl = `https://github.com/${repoUrl}`;
@@ -261,7 +261,7 @@ if (typeof module !== 'undefined' && module.parent) {
 
     // Get branch from parameters if possible
     if (process.argv.length > 3) {
-        repoBranch = process.argv[ 3 ];
+        repoBranch = process.argv[3];
     }
 
     common.info(`Checking repository ${repoUrl} (branch ${repoBranch})`);

--- a/lib/M5000_Code.js
+++ b/lib/M5000_Code.js
@@ -18,7 +18,7 @@ const common = require('./common.js');
 const M5500__jsonConfig = require('./M5500__JsonConfig.js');
 
 // YAML file extensions for validation
-const yamlExtensions = [ '.yml', '.yaml' ];
+const yamlExtensions = ['.yml', '.yaml'];
 
 // Known Node.js built-in modules (can be used with node: prefix)
 const NODE_BUILT_INS = new Set([
@@ -67,26 +67,26 @@ const NODE_BUILT_INS = new Set([
 ]);
 
 // utility to parse words.js
-function extractWords (words) {
+function extractWords(words) {
     try {
         const lines = words.split(/\r\n|\r|\n/g);
         let i = 0;
-        while (!lines[ i ].match(/^systemDictionary = {/)) {
+        while (!lines[i].match(/^systemDictionary = {/)) {
             i++;
         }
         lines.splice(0, i);
 
         // remove last empty lines
         i = lines.length - 1;
-        while (!lines[ i ]) {
+        while (!lines[i]) {
             i--;
         }
         if (i < lines.length - 1) {
             lines.splice(i + 1);
         }
 
-        lines[ 0 ] = lines[ 0 ].replace('systemDictionary = ', '');
-        lines[ lines.length - 1 ] = lines[ lines.length - 1 ].trim().replace(/};$/, '}');
+        lines[0] = lines[0].replace('systemDictionary = ', '');
+        lines[lines.length - 1] = lines[lines.length - 1].trim().replace(/};$/, '}');
         words = lines.join('\n');
         const resultFunc = new Function(`return ${words};`);
 
@@ -96,20 +96,20 @@ function extractWords (words) {
     }
 }
 
-function getAllFiles (context, dirPath, root, filesList) {
-    const skipDirectories = [ '.dev-server', 'node_modules', '.git', '.vscode' ];
+function getAllFiles(context, dirPath, root, filesList) {
+    const skipDirectories = ['.dev-server', 'node_modules', '.git', '.vscode'];
     const files = fs.readdirSync(dirPath);
     filesList = filesList || [];
     files.forEach(file => {
         if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
             if (!skipDirectories.includes(file)) {
-                filesList = getAllFiles(context, path.join(dirPath, file), [ root, file ].join('/'), filesList);
+                filesList = getAllFiles(context, path.join(dirPath, file), [root, file].join('/'), filesList);
             }
         } else {
-            const filePath = [ root, file ].join('/');
+            const filePath = [root, file].join('/');
             filesList.push(filePath);
             if (context.readFiles && context.readFiles.includes(filePath)) {
-                context[ filePath ] = fs.readFileSync(path.join(dirPath, file), 'utf8');
+                context[filePath] = fs.readFileSync(path.join(dirPath, file), 'utf8');
             }
         }
     });
@@ -125,7 +125,7 @@ function getAllFiles (context, dirPath, root, filesList) {
  * @param {string} targetKey - The key to search for
  * @returns {boolean} true if the key is found anywhere in the object
  */
-function hasKeyInObject (obj, targetKey) {
+function hasKeyInObject(obj, targetKey) {
     if (typeof obj !== 'object' || obj === null) {
         return false;
     }
@@ -143,19 +143,19 @@ function hasKeyInObject (obj, targetKey) {
  * @param {string} key - The config key to check (e.g. 'option1')
  * @returns {boolean} true if the key is referenced in any admin UI file
  */
-function isKeyUsedInAdminConfig (context, key) {
-    if (context[ '/admin/index.html' ] && context[ '/admin/index.html' ].includes(key)) {
+function isKeyUsedInAdminConfig(context, key) {
+    if (context['/admin/index.html'] && context['/admin/index.html'].includes(key)) {
         return true;
     }
-    if (context[ '/admin/index_m.html' ] && context[ '/admin/index_m.html' ].includes(key)) {
+    if (context['/admin/index_m.html'] && context['/admin/index_m.html'].includes(key)) {
         return true;
     }
-    const jsonConfigRaw = context[ '/admin/jsonConfig.json' ] || context[ '/admin/jsonConfig.json5' ];
+    const jsonConfigRaw = context['/admin/jsonConfig.json'] || context['/admin/jsonConfig.json5'];
     if (jsonConfigRaw) {
         try {
-            const parsed = context[ '/admin/jsonConfig.json' ]
-                ? JSON.parse(context[ '/admin/jsonConfig.json' ])
-                : JSON5.parse(context[ '/admin/jsonConfig.json5' ]);
+            const parsed = context['/admin/jsonConfig.json']
+                ? JSON.parse(context['/admin/jsonConfig.json'])
+                : JSON5.parse(context['/admin/jsonConfig.json5']);
             if (hasKeyInObject(parsed, key)) {
                 return true;
             }
@@ -174,14 +174,14 @@ function isKeyUsedInAdminConfig (context, key) {
  * @param {string} importPath - The raw import path
  * @returns {string} The base package name
  */
-function extractPackageName (importPath) {
+function extractPackageName(importPath) {
     if (importPath.startsWith('@')) {
         // Scoped package: @scope/name/... -> @scope/name
         const parts = importPath.split('/');
         return parts.slice(0, 2).join('/');
     }
     // Regular package: name/... -> name
-    return importPath.split('/')[ 0 ];
+    return importPath.split('/')[0];
 }
 
 /**
@@ -192,7 +192,7 @@ function extractPackageName (importPath) {
  * @param {string} content - Source file content
  * @returns {string} Content with comments removed
  */
-function stripComments (content) {
+function stripComments(content) {
     // Remove block comments (/* ... */)
     let result = content.replace(/\/\*[\s\S]*?\*\//g, '');
     // Remove single-line comments (// ...)
@@ -206,7 +206,7 @@ function stripComments (content) {
  * @param {string} content - File content
  * @returns {string[]} Array of unique import targets
  */
-function extractImports (content) {
+function extractImports(content) {
     const imports = new Set();
 
     // Strip comments first to avoid matching require/import patterns inside comments
@@ -216,8 +216,8 @@ function extractImports (content) {
     const requirePattern = /\brequire\s*\(\s*['"`]([^'"`\n]+)['"`]\s*\)/g;
     let match;
     while ((match = requirePattern.exec(code)) !== null) {
-        common.debug(`    require:     found ${match[ 1 ]}`);
-        imports.add(match[ 1 ]);
+        common.debug(`    require:     found ${match[1]}`);
+        imports.add(match[1]);
     }
 
     // import ... from '...' (handles multi-line imports too)
@@ -231,28 +231,28 @@ function extractImports (content) {
     // `import type { Foo } from 'pkg'` which do not require runtime dependencies.
     const fromPattern = /\b(?:import)\b(?!\s*\()(?!\s+type\b)[\s\S]*?\bfrom\s+['"`]([^'"`\n]+)['"`]/g;
     while ((match = fromPattern.exec(code)) !== null) {
-        common.debug(`    import from: found ${match[ 1 ]}`);
-        imports.add(match[ 1 ]);
+        common.debug(`    import from: found ${match[1]}`);
+        imports.add(match[1]);
     }
 
     // Side-effect imports: import 'package'
     const sideEffectImportPattern = /\bimport\s+['"`]([^'"`\n]+)['"`]/g;
     while ((match = sideEffectImportPattern.exec(code)) !== null) {
-        common.debug(`    import ...:  found ${match[ 1 ]}`);
-        imports.add(match[ 1 ]);
+        common.debug(`    import ...:  found ${match[1]}`);
+        imports.add(match[1]);
     }
 
     // dynamic import('...')
     const dynamicImportPattern = /\bimport\s*\(\s*['"`]([^'"`\n]+)['"`]\s*\)/g;
     while ((match = dynamicImportPattern.exec(code)) !== null) {
-        common.debug(`    dyn import:  found ${match[ 1 ]}`);
-        imports.add(match[ 1 ]);
+        common.debug(`    dyn import:  found ${match[1]}`);
+        imports.add(match[1]);
     }
 
-    return [ ...imports ];
+    return [...imports];
 }
 
-async function checkCode (context) {
+async function checkCode(context) {
     console.log('\n[E5000 - E5999] checkCode');
 
     const readFiles = [
@@ -301,8 +301,8 @@ async function checkCode (context) {
     }
 
     // Add all executable files (.js, .mjs, .cjs, .ts) to readFiles, excluding certain directories
-    const executableExtensions = [ '.js', '.mjs', '.cjs', '.ts' ];
-    const excludeDirsForExecutables = [ 'node_modules', 'admin', 'admin-src', '.git', '.vscode', '.dev-server' ];
+    const executableExtensions = ['.js', '.mjs', '.cjs', '.ts'];
+    const excludeDirsForExecutables = ['node_modules', 'admin', 'admin-src', '.git', '.vscode', '.dev-server'];
 
     tempFilesList.forEach(filePath => {
         // Skip files in excluded directories
@@ -322,7 +322,7 @@ async function checkCode (context) {
     });
 
     // Add all YAML files (.yml, .yaml) to readFiles for validation
-    const excludeDirsForYaml = [ 'node_modules', '.git', '.vscode', '.dev-server' ];
+    const excludeDirsForYaml = ['node_modules', '.git', '.vscode', '.dev-server'];
 
     tempFilesList.forEach(filePath => {
         // Skip files in excluded directories
@@ -389,7 +389,7 @@ async function checkCode (context) {
 
             if (readFiles.includes(fileName)) {
                 common.debug(`    reading ${fileName}`);
-                context[ fileName ] = await common.getFile(context, fileName);
+                context[fileName] = await common.getFile(context, fileName);
             }
         }
     }
@@ -410,14 +410,14 @@ async function checkCode (context) {
     // W5041: Check i18n translation files for example keys (option1/option2).
     // Only raise warning if the keys are not actually used in admin UI files (index.html, index_m.html, or jsonConfig).
     if (!context.hasExampleConfigWarning) {
-        const exampleKeys = [ 'option1', 'option2' ];
+        const exampleKeys = ['option1', 'option2'];
         const foundI18nKeys = new Set();
         const foundI18nLangs = new Set();
         for (const lang of context.cfg.allowedLanguages) {
-            for (const i18nPath of [ `/admin/i18n/${lang}/translations.json`, `/admin/i18n/${lang}.json` ]) {
-                if (context[ i18nPath ]) {
+            for (const i18nPath of [`/admin/i18n/${lang}/translations.json`, `/admin/i18n/${lang}.json`]) {
+                if (context[i18nPath]) {
                     try {
-                        const i18nContent = JSON.parse(context[ i18nPath ]);
+                        const i18nContent = JSON.parse(context[i18nPath]);
                         const unusedI18nKeys = exampleKeys.filter(
                             key =>
                                 Object.prototype.hasOwnProperty.call(i18nContent, key) &&
@@ -436,8 +436,8 @@ async function checkCode (context) {
             }
         }
         if (foundI18nKeys.size) {
-            const keyList = [ ...foundI18nKeys ].join(', ');
-            const langList = [ ...foundI18nLangs ].join(', ');
+            const keyList = [...foundI18nKeys].join(', ');
+            const langList = [...foundI18nLangs].join(', ');
             context.warnings.push(
                 `[W5041] Example configuration (${keyList}) found in i18n translation files (${langList}). Please remove example configuration from your code.`,
             );
@@ -447,7 +447,7 @@ async function checkCode (context) {
 
     // Check for conflicting JavaScript file extensions in the same directory
     // W5034: Files with the same base name but different extensions (.ts, .js, .cjs, .mjs) in the same directory
-    const jsExtensions = [ '.ts', '.js', '.cjs', '.mjs' ];
+    const jsExtensions = ['.ts', '.js', '.cjs', '.mjs'];
     const filesByDirectory = new Map();
 
     // Group files by directory and base name
@@ -487,7 +487,7 @@ async function checkCode (context) {
 
     // Check for conflicting JSON file extensions in the same directory
     // E5038: Files with the same base name but different extensions (.json, .json5) in the same directory
-    const jsonExtensions = [ '.json', '.json5' ];
+    const jsonExtensions = ['.json', '.json5'];
     const jsonFilesByDirectory = new Map();
 
     // Group files by directory and base name
@@ -529,14 +529,14 @@ async function checkCode (context) {
     // Check all YAML files (.yml, .yaml) for valid syntax
     // E5035: YAML file cannot be parsed
     for (const fileName of Object.keys(context)) {
-        if (fileName.startsWith('/') && typeof context[ fileName ] === 'string') {
+        if (fileName.startsWith('/') && typeof context[fileName] === 'string') {
             const ext = path.extname(fileName);
             if (yamlExtensions.includes(ext)) {
                 try {
-                    yaml.load(context[ fileName ]);
+                    yaml.load(context[fileName]);
                 } catch (e) {
                     context.errors.push(
-                        `[E5035] Cannot parse YAML file "${fileName.slice(1)}": ${e.message.split('\n')[ 0 ]}`,
+                        `[E5035] Cannot parse YAML file "${fileName.slice(1)}": ${e.message.split('\n')[0]}`,
                     );
                 }
             }
@@ -546,55 +546,55 @@ async function checkCode (context) {
     let usesReact = false;
     if (
         context.packageJson.devDependencies &&
-        (context.packageJson.devDependencies[ '@iobroker/adapter-react-v5' ] ||
-            context.packageJson.devDependencies[ 'react' ])
+        (context.packageJson.devDependencies['@iobroker/adapter-react-v5'] ||
+            context.packageJson.devDependencies['react'])
     ) {
         common.info('REACT detected at package devDependencies');
         usesReact = true;
     }
     if (
         context.packageJson.dependencies &&
-        (context.packageJson.dependencies[ '@iobroker/adapter-react-v5' ] || context.packageJson.dependencies[ 'react' ])
+        (context.packageJson.dependencies['@iobroker/adapter-react-v5'] || context.packageJson.dependencies['react'])
     ) {
         common.info('REACT detected at package dependencies');
         usesReact = true;
     }
-    if (context[ '/src-admin/package.json' ]) {
-        const packageJson = JSON.parse(context[ '/src-admin/package.json' ]);
-        if (packageJson.devDependencies && packageJson.devDependencies[ '@iobroker/adapter-react-v5' ]) {
+    if (context['/src-admin/package.json']) {
+        const packageJson = JSON.parse(context['/src-admin/package.json']);
+        if (packageJson.devDependencies && packageJson.devDependencies['@iobroker/adapter-react-v5']) {
             common.info('REACT detected at src-admin/package devDependencies');
             usesReact = true;
         }
-        if (packageJson.dependencies && packageJson.dependencies[ '@iobroker/adapter-react-v5' ]) {
+        if (packageJson.dependencies && packageJson.dependencies['@iobroker/adapter-react-v5']) {
             common.info('REACT detected at src-admin/package dependencies');
             usesReact = true;
         }
     }
-    if (context[ '/src-widgets/package.json' ]) {
-        const packageJson = JSON.parse(context[ '/src-widgets/package.json' ]);
+    if (context['/src-widgets/package.json']) {
+        const packageJson = JSON.parse(context['/src-widgets/package.json']);
         if (
             packageJson.devDependencies &&
-            (packageJson.devDependencies[ '@iobroker/adapter-react-v5' ] || packageJson.devDependencies[ 'react' ])
+            (packageJson.devDependencies['@iobroker/adapter-react-v5'] || packageJson.devDependencies['react'])
         ) {
             common.info('REACT detected at src-widgets/package devDependencies');
             usesReact = true;
         }
         if (
             packageJson.dependencies &&
-            (packageJson.dependencies[ '@iobroker/adapter-react-v5' ] || packageJson.dependencies[ 'react' ])
+            (packageJson.dependencies['@iobroker/adapter-react-v5'] || packageJson.dependencies['react'])
         ) {
             common.info('REACT detected at src-widgets/package dependencies');
             usesReact = true;
         }
     }
-    if (context[ '/src/package.json' ]) {
+    if (context['/src/package.json']) {
         //console.log('"src/package.json" exists');
-        const packageJson = JSON.parse(context[ '/src/package.json' ]);
-        if (packageJson.devDependencies && packageJson.devDependencies[ '@iobroker/adapter-react-v5' ]) {
+        const packageJson = JSON.parse(context['/src/package.json']);
+        if (packageJson.devDependencies && packageJson.devDependencies['@iobroker/adapter-react-v5']) {
             // console.log('REACT detected');
             usesReact = true;
         }
-        if (packageJson.dependencies && packageJson.dependencies[ '@iobroker/adapter-react-v5' ]) {
+        if (packageJson.dependencies && packageJson.dependencies['@iobroker/adapter-react-v5']) {
             // console.log('REACT detected');
             usesReact = true;
         }
@@ -615,30 +615,30 @@ async function checkCode (context) {
         (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.config === 'materialize')
     ) {
         if (
-            context[ '/admin/index_m.html' ] &&
-            context[ '/admin/index_m.html' ].includes('selectID.js') &&
+            context['/admin/index_m.html'] &&
+            context['/admin/index_m.html'].includes('selectID.js') &&
             !context.filesList.includes('/admin/img/info-big.png')
         ) {
             context.errors.push('[E5002] "/admin/img/info-big.png" not found, but selectID.js used in index_m.html ');
         }
 
-        if (context[ '/admin/words.js' ]) {
+        if (context['/admin/words.js']) {
             // at least 3 languages must be in
-            const words = extractWords(context[ '/admin/words.js' ]);
+            const words = extractWords(context['/admin/words.js']);
             if (words) {
-                const problem = Object.keys(words).filter(word => !words[ word ].de || !words[ word ].ru);
+                const problem = Object.keys(words).filter(word => !words[word].de || !words[word].ru);
                 if (problem.length > 3) {
                     context.errors.push(
                         `[E5006] More non translated in german or russian words found in admin/words.js. You can use https://translator.iobroker.in/ for translations`,
                     );
                 } else {
                     problem.forEach(word => {
-                        if (!words[ word ].de) {
+                        if (!words[word].de) {
                             context.errors.push(
                                 `[E5006] Word "${word}" is not translated to german in admin/words.js. You can use https://translator.iobroker.in/ for translations`,
                             );
                         }
-                        if (!words[ word ].ru) {
+                        if (!words[word].ru) {
                             context.errors.push(
                                 `[E5006] Word "${word}" is not translated to russian in admin/words.js. You can use https://translator.iobroker.in/ for translations`,
                             );
@@ -653,34 +653,34 @@ async function checkCode (context) {
 
     if (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.config === 'json') {
         let jsonConfig;
-        if (context[ '/admin/jsonConfig.json' ] || context[ '/admin/jsonConfig.json5' ]) {
+        if (context['/admin/jsonConfig.json'] || context['/admin/jsonConfig.json5']) {
             try {
-                jsonConfig = context[ '/admin/jsonConfig.json' ]
-                    ? JSON.parse(context[ '/admin/jsonConfig.json' ])
-                    : JSON5.parse(context[ '/admin/jsonConfig.json5' ]);
+                jsonConfig = context['/admin/jsonConfig.json']
+                    ? JSON.parse(context['/admin/jsonConfig.json'])
+                    : JSON5.parse(context['/admin/jsonConfig.json5']);
             } catch (e) {
                 context.errors.push(
-                    `[E5007] Cannot parse "/admin/jsonConfig.json${context[ '/admin/jsonConfig.json' ] ? '' : '5'}": ${e}`,
+                    `[E5007] Cannot parse "/admin/jsonConfig.json${context['/admin/jsonConfig.json'] ? '' : '5'}": ${e}`,
                 );
             }
         } else {
             context.errors.push(
-                `[E5008] "admin/jsonConfig.json${context[ '/admin/jsonConfig.json' ] ? '' : '5'}" not found, but admin support is declared`,
+                `[E5008] "admin/jsonConfig.json${context['/admin/jsonConfig.json'] ? '' : '5'}" not found, but admin support is declared`,
             );
         }
 
         if (jsonConfig) {
             if (jsonConfig.i18n === true) {
                 context.cfg.allowedLanguages.forEach(lang => {
-                    if (context[ `/admin/i18n/${lang}/translations.json` ]) {
+                    if (context[`/admin/i18n/${lang}/translations.json`]) {
                         try {
-                            JSON.parse(context[ `/admin/i18n/${lang}/translations.json` ]);
+                            JSON.parse(context[`/admin/i18n/${lang}/translations.json`]);
                         } catch (e) {
                             context.errors.push(`[E5009] Cannot parse "admin/i18n/${lang}/translations.json": ${e}`);
                         }
-                    } else if (context[ `/admin/i18n/${lang}.json` ]) {
+                    } else if (context[`/admin/i18n/${lang}.json`]) {
                         try {
-                            JSON.parse(context[ `/admin/i18n/${lang}.json` ]);
+                            JSON.parse(context[`/admin/i18n/${lang}.json`]);
                         } catch (e) {
                             context.errors.push(`[E5009] Cannot parse "admin/i18n/${lang}.json": ${e}`);
                         }
@@ -698,7 +698,7 @@ async function checkCode (context) {
 
             M5500__jsonConfig.checkJsonConfig(
                 context,
-                `admin/jsonConfig.json${context[ '/admin/jsonConfig.json' ] ? '' : '5'}`,
+                `admin/jsonConfig.json${context['/admin/jsonConfig.json'] ? '' : '5'}`,
                 jsonConfig,
             );
         } // if (jsonConfig) ...
@@ -722,8 +722,8 @@ async function checkCode (context) {
             '/.create-adapter.json',
         ];
         for (const fileName of Object.keys(context)) {
-            if (fileName.startsWith('/') && typeof context[ fileName ] === 'string' && !excludeFiles.includes(fileName)) {
-                const content = context[ fileName ];
+            if (fileName.startsWith('/') && typeof context[fileName] === 'string' && !excludeFiles.includes(fileName)) {
+                const content = context[fileName];
                 // Detect references to words.js in various forms:
                 // - Direct file name: words.js (e.g. in HTML script tags)
                 // - Path-prefixed: ./words, ../words, admin/words (with or without .js extension)
@@ -774,7 +774,7 @@ async function checkCode (context) {
         context.ioPackageJson.common.adminUI.config === 'json' &&
         (context.filesList.includes('/admin/jsonConfig.json') || context.filesList.includes('/admin/jsonConfig.json5'))
     ) {
-        const obsoleteFiles = [ '/admin/index.html', '/admin/index_m.html', '/admin/style.css' ];
+        const obsoleteFiles = ['/admin/index.html', '/admin/index_m.html', '/admin/style.css'];
         for (const file of obsoleteFiles) {
             if (context.filesList.includes(file)) {
                 context.warnings.push(
@@ -789,37 +789,37 @@ async function checkCode (context) {
         context.ioPackageJson.common.jsonCustom ||
         (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.custom === 'json')
     ) {
-        if (context[ '/admin/jsonCustom.json' ] || context[ '/admin/jsonCustom.json5' ]) {
+        if (context['/admin/jsonCustom.json'] || context['/admin/jsonCustom.json5']) {
             try {
-                context[ '/admin/jsonCustom.json' ]
-                    ? JSON.parse(context[ '/admin/jsonCustom.json' ])
-                    : JSON5.parse(context[ '/admin/jsonCustom.json5' ]);
+                context['/admin/jsonCustom.json']
+                    ? JSON.parse(context['/admin/jsonCustom.json'])
+                    : JSON5.parse(context['/admin/jsonCustom.json5']);
             } catch (e) {
                 context.errors.push(
-                    `[E5011] Cannot parse "/admin/jsonCustom.json${context[ '/admin/jsonCustom.json' ] ? '' : '5'}": ${e}`,
+                    `[E5011] Cannot parse "/admin/jsonCustom.json${context['/admin/jsonCustom.json'] ? '' : '5'}": ${e}`,
                 );
             }
         } else {
             context.errors.push(
-                `[E5012] "/admin/jsonCustom.json${context[ '/admin/jsonCustom.json' ] ? '' : '5'}" not found, but custom support is declared`,
+                `[E5012] "/admin/jsonCustom.json${context['/admin/jsonCustom.json'] ? '' : '5'}" not found, but custom support is declared`,
             );
         }
     }
 
     if (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.tab === 'json') {
-        if (context[ '/admin/jsonTab.json' ] || context[ '/admin/jsonTab.json5' ]) {
+        if (context['/admin/jsonTab.json'] || context['/admin/jsonTab.json5']) {
             try {
-                context[ '/admin/jsonTab.json' ]
-                    ? JSON.parse(context[ '/admin/jsonTab.json' ])
-                    : JSON5.parse(context[ '/admin/jsonTab.json5' ]);
+                context['/admin/jsonTab.json']
+                    ? JSON.parse(context['/admin/jsonTab.json'])
+                    : JSON5.parse(context['/admin/jsonTab.json5']);
             } catch (e) {
                 context.errors.push(
-                    `[E5044] Cannot parse "/admin/jsonTab.json${context[ '/admin/jsonTab.json' ] ? '' : '5'}": ${e}`,
+                    `[E5044] Cannot parse "/admin/jsonTab.json${context['/admin/jsonTab.json'] ? '' : '5'}": ${e}`,
                 );
             }
         } else {
             context.errors.push(
-                `[E5045] "/admin/jsonTab.json${context[ '/admin/jsonTab.json' ] ? '' : '5'}" not found, but tab support is declared`,
+                `[E5045] "/admin/jsonTab.json${context['/admin/jsonTab.json'] ? '' : '5'}" not found, but tab support is declared`,
             );
         }
     }
@@ -835,12 +835,12 @@ async function checkCode (context) {
     ];
 
     for (const configFile of jsonConfigFilesToValidate) {
-        if (context[ configFile ]) {
+        if (context[configFile]) {
             let parsed;
             try {
                 parsed = configFile.endsWith('.json5')
-                    ? JSON5.parse(context[ configFile ])
-                    : JSON.parse(context[ configFile ]);
+                    ? JSON5.parse(context[configFile])
+                    : JSON.parse(context[configFile]);
             } catch (e) {
                 common.debug(`Could not parse ${configFile} for schema validation: ${e.message}`);
                 context.warnings.push(
@@ -853,7 +853,7 @@ async function checkCode (context) {
         }
     }
 
-    if (context.ioPackageJson.common.blockly && !context[ '/admin/blockly.js' ]) {
+    if (context.ioPackageJson.common.blockly && !context['/admin/blockly.js']) {
         context.errors.push('[E5014] "/admin/blockly.js" not found, but blockly support is declared');
     }
 
@@ -870,7 +870,7 @@ async function checkCode (context) {
         }
     }
 
-    const forbiddenFiles = [ '/iob_npm.done', '/iob', '/iobroker' ];
+    const forbiddenFiles = ['/iob_npm.done', '/iob', '/iobroker'];
 
     forbiddenFiles.forEach(file => {
         if (context.filesList.includes(file)) {
@@ -884,18 +884,18 @@ async function checkCode (context) {
         );
     }
 
-    if (context[ '/.travis.yml' ]) {
+    if (context['/.travis.yml']) {
         context.hasTravis = true;
     }
 
-    if (context[ '/gulpfile.js' ]) {
-        if (!context.packageJson.devDependencies[ 'gulp' ]) {
+    if (context['/gulpfile.js']) {
+        if (!context.packageJson.devDependencies['gulp']) {
             context.warnings.push(
                 '[W5020] "gulpfile.js" found in repo but "gulp" not found at devDependencies at package.json. Check whether it can be removed.',
             );
         } else if (!usesReact) {
             // Check if @iobroker/adapter-dev is present in devDependencies
-            if (context.packageJson.devDependencies && context.packageJson.devDependencies[ '@iobroker/adapter-dev' ]) {
+            if (context.packageJson.devDependencies && context.packageJson.devDependencies['@iobroker/adapter-dev']) {
                 context.warnings.push(
                     '[S5031] "gulpfile.js" found in repo while @iobroker/adapter-dev already used. Please check if gulp is still needed.',
                 );
@@ -906,7 +906,7 @@ async function checkCode (context) {
             }
         }
     } else {
-        if (context.packageJson.devDependencies[ 'gulp' ]) {
+        if (context.packageJson.devDependencies['gulp']) {
             context.warnings.push(
                 '[W5021] "gulp" found at devDependencies at package.json but no "gulpfile.js" found. Is this dependency really required?',
             );
@@ -914,7 +914,7 @@ async function checkCode (context) {
     }
 
     // W5048: Check for obsolete eslint/prettier config files when @iobroker/eslint-config is used
-    if (context.packageJson.devDependencies && context.packageJson.devDependencies[ '@iobroker/eslint-config' ]) {
+    if (context.packageJson.devDependencies && context.packageJson.devDependencies['@iobroker/eslint-config']) {
         const obsoleteFiles = [
             '/.eslintignore',
             '/.eslintrc.json',
@@ -931,17 +931,17 @@ async function checkCode (context) {
         }
     }
 
-    if (context.packageJson.devDependencies && context.packageJson.devDependencies[ '@alcalzone/release-script' ]) {
-        const version = context.packageJson.devDependencies[ '@alcalzone/release-script' ];
+    if (context.packageJson.devDependencies && context.packageJson.devDependencies['@alcalzone/release-script']) {
+        const version = context.packageJson.devDependencies['@alcalzone/release-script'];
         if (compareVersions.compareVersions(version, '3.0.0') >= 0) {
-            if (!context[ '/.releaseconfig.json' ]) {
+            if (!context['/.releaseconfig.json']) {
                 context.errors.push(
                     '[E5018] "@alcalzone/release-script" (>=3.0.0) is used, but ".releaseconfig.json" not found. Please create.',
                 );
             } else {
-                common.debug(`context[/.releaseconfig.json: ${context[ '/.releaseconfig.json' ]}`);
+                common.debug(`context[/.releaseconfig.json: ${context['/.releaseconfig.json']}`);
                 try {
-                    const releaseConfigJson = JSON.parse(context[ '/.releaseconfig.json' ]);
+                    const releaseConfigJson = JSON.parse(context['/.releaseconfig.json']);
                     common.debug(`releaseConfigJson: ${releaseConfigJson}`);
 
                     const plugins = releaseConfigJson.plugins || [];
@@ -960,22 +960,22 @@ async function checkCode (context) {
                     };
 
                     // Required plugins for ioBroker adapters
-                    const requiredPlugins = [ 'iobroker', 'license' ];
+                    const requiredPlugins = ['iobroker', 'license'];
                     // Suggested plugins for ioBroker adapters
-                    const suggestedPlugins = [ 'manual-review' ];
+                    const suggestedPlugins = ['manual-review'];
 
                     // Check required plugins are installed as devDependencies
-                    if (!context.packageJson.devDependencies[ '@alcalzone/release-script-plugin-iobroker' ]) {
+                    if (!context.packageJson.devDependencies['@alcalzone/release-script-plugin-iobroker']) {
                         context.errors.push(
                             '[E5024] "@alcalzone/release-script" requires plugin "@alcalzone/release-script-plugin-iobroker". Please add.',
                         );
                     }
-                    if (!context.packageJson.devDependencies[ '@alcalzone/release-script-plugin-license' ]) {
+                    if (!context.packageJson.devDependencies['@alcalzone/release-script-plugin-license']) {
                         context.errors.push(
                             '[E5025] "@alcalzone/release-script" requires plugin "@alcalzone/release-script-plugin-license". Please add.',
                         );
                     }
-                    if (!context.packageJson.devDependencies[ '@alcalzone/release-script-plugin-manual-review' ]) {
+                    if (!context.packageJson.devDependencies['@alcalzone/release-script-plugin-manual-review']) {
                         context.warnings.push(
                             '[S5026] Consider adding plugin "@alcalzone/release-script-plugin-manual-review".',
                         );
@@ -983,8 +983,8 @@ async function checkCode (context) {
 
                     // Check all plugins listed in .releaseconfig.json are installed as devDependencies
                     for (const plugin of plugins) {
-                        const packageName = pluginToPackage[ plugin ];
-                        if (packageName && !context.packageJson.devDependencies[ packageName ]) {
+                        const packageName = pluginToPackage[plugin];
+                        if (packageName && !context.packageJson.devDependencies[packageName]) {
                             context.errors.push(
                                 `[E5036] Plugin "${plugin}" is listed at .releaseconfig.json but "${packageName}" is not installed as devDependency. Please add.`,
                             );
@@ -993,8 +993,8 @@ async function checkCode (context) {
 
                     // Check all installed plugin devDependencies are listed in .releaseconfig.json
                     for (const pluginName in pluginToPackage) {
-                        const packageName = pluginToPackage[ pluginName ];
-                        if (context.packageJson.devDependencies[ packageName ]) {
+                        const packageName = pluginToPackage[pluginName];
+                        if (context.packageJson.devDependencies[packageName]) {
                             if (!plugins.includes(pluginName)) {
                                 if (requiredPlugins.includes(pluginName)) {
                                     context.errors.push(
@@ -1020,7 +1020,7 @@ async function checkCode (context) {
     }
 
     if (context.packageJson.main && context.packageJson.main.endsWith('.js')) {
-        if (!context[ `/${context.packageJson.main}` ]) {
+        if (!context[`/${context.packageJson.main}`]) {
             if (!context.ioPackageJson.common.nogit) {
                 context.errors.push(
                     `[E5019] "${context.packageJson.main}" found in package.json, but not found as file`,
@@ -1028,8 +1028,8 @@ async function checkCode (context) {
             }
         } else {
             if (
-                context[ `/${context.packageJson.main}` ].includes('setInterval(') &&
-                !context[ `/${context.packageJson.main}` ].includes('clearInterval(')
+                context[`/${context.packageJson.main}`].includes('setInterval(') &&
+                !context[`/${context.packageJson.main}`].includes('clearInterval(')
             ) {
                 if (context.ioPackageJson.common.compact) {
                     // if compact mode supported, it is critical
@@ -1043,8 +1043,8 @@ async function checkCode (context) {
                 }
             }
             if (
-                context[ `/${context.packageJson.main}` ].includes('setTimeout(') &&
-                !context[ `/${context.packageJson.main}` ].includes('clearTimeout(')
+                context[`/${context.packageJson.main}`].includes('setTimeout(') &&
+                !context[`/${context.packageJson.main}`].includes('clearTimeout(')
             ) {
                 if (context.ioPackageJson.common.compact) {
                     // if compact mode supported, it is critical
@@ -1068,8 +1068,8 @@ async function checkCode (context) {
 
         // Search through all loaded files for references to tools.js
         for (const fileName of Object.keys(context)) {
-            if (fileName.startsWith('/') && typeof context[ fileName ] === 'string') {
-                const content = context[ fileName ];
+            if (fileName.startsWith('/') && typeof context[fileName] === 'string') {
+                const content = context[fileName];
                 // Look for various patterns that might reference lib/tools.js
                 if (
                     content.includes('lib/tools') ||
@@ -1111,7 +1111,7 @@ async function checkCode (context) {
      * @param {number} lineIndex - Current line index being checked
      * @returns {boolean} True if the line is within an adapter class context
      */
-    function isInAdapterClassContext (lines, lineIndex) {
+    function isInAdapterClassContext(lines, lineIndex) {
         // Look backwards and forwards to understand the context
         // const contextRange = 50; // Look within 50 lines for class context
         const contextRange = 1000; // Look within 1000 lines for class context
@@ -1120,7 +1120,7 @@ async function checkCode (context) {
 
         // Check for class that extends utils.Adapter pattern
         for (let i = startIdx; i < endIdx; i++) {
-            const line = lines[ i ].trim();
+            const line = lines[i].trim();
 
             // Pattern 1: class SomeClass extends utils.Adapter
             if (/class\s+\w+\s+extends\s+utils\.Adapter/i.test(line)) {
@@ -1130,7 +1130,7 @@ async function checkCode (context) {
                     let braceCount = 0;
                     let foundOpenBrace = false;
                     for (let j = i; j <= lineIndex; j++) {
-                        const checkLine = lines[ j ];
+                        const checkLine = lines[j];
                         for (const char of checkLine) {
                             if (char === '{') {
                                 braceCount++;
@@ -1159,7 +1159,7 @@ async function checkCode (context) {
                 let braceCount = 0;
                 let foundOpenBrace = false;
                 for (let j = i; j <= lineIndex; j++) {
-                    const checkLine = lines[ j ];
+                    const checkLine = lines[j];
                     for (const char of checkLine) {
                         if (char === '{') {
                             braceCount++;
@@ -1182,12 +1182,12 @@ async function checkCode (context) {
         }
 
         // Check if the method call is actually to a local function by looking for function definitions
-        const methodCallMatch = lines[ lineIndex ].match(/this\.(\w+)\s*\(/);
+        const methodCallMatch = lines[lineIndex].match(/this\.(\w+)\s*\(/);
         if (methodCallMatch) {
-            const methodName = methodCallMatch[ 1 ];
+            const methodName = methodCallMatch[1];
             // Look for local function definition of this method
             for (let i = 0; i < lines.length; i++) {
-                const line = lines[ i ].trim();
+                const line = lines[i].trim();
                 // Pattern: this.methodName = function or this.methodName = async function
                 if (new RegExp(`this\\.${methodName}\\s*=\\s*(async\\s+)?function`, 'i').test(line)) {
                     return false; // It's a local function, not adapter method
@@ -1203,7 +1203,7 @@ async function checkCode (context) {
 
     // Search through all loaded executable files for deprecated method usage
     for (const fileName of Object.keys(context)) {
-        if (fileName.startsWith('/') && typeof context[ fileName ] === 'string') {
+        if (fileName.startsWith('/') && typeof context[fileName] === 'string') {
             // Skip files in excluded directories (admin, tests, etc.)
             const pathParts = fileName.split('/').filter(part => part !== '');
             const isInExcludedDir = pathParts.some(part => excludeDirsForExecutables.includes(part));
@@ -1214,16 +1214,16 @@ async function checkCode (context) {
 
             // Only check executable files
             const ext = path.extname(fileName);
-            const executableExtensions = [ '.js', '.mjs', '.cjs', '.ts' ];
+            const executableExtensions = ['.js', '.mjs', '.cjs', '.ts'];
             if (!executableExtensions.includes(ext)) {
                 continue;
             }
 
-            const content = context[ fileName ];
+            const content = context[fileName];
             const lines = content.split(/\r\n|\r|\n/g);
 
             for (let i = 0; i < lines.length; i++) {
-                const line = lines[ i ];
+                const line = lines[i];
 
                 for (const method of deprecatedMethods) {
                     // Skip if this method has already been reported
@@ -1279,12 +1279,12 @@ async function checkCode (context) {
     }
 
     // Packages known to be provided by the js-controller/system and therefore not required as dependencies
-    const systemProvidedPackages = new Set([ '@iobroker/plugin-sentry' ]);
+    const systemProvidedPackages = new Set(['@iobroker/plugin-sentry']);
 
     // W5042/S5043: Scan source files for require/import statements and check dependencies
     // Exclude files in admin/, build/, doc/, src-admin/, admin-src/, test/ directories
     // and *.test.* and *.config.* files
-    const sourceFileExtensions = new Set([ '.js', '.mjs', '.cjs', '.ts' ]);
+    const sourceFileExtensions = new Set(['.js', '.mjs', '.cjs', '.ts']);
     const excludedSourceDirs = new Set([
         'admin',
         'build',
@@ -1303,10 +1303,10 @@ async function checkCode (context) {
         '.dev-server',
     ]);
     // Exact file base names to exclude from dependency scanning
-    const excludedSourceFiles = new Set([ 'tasks.js', 'Gruntfile.js', 'gulpfile.js' ]);
+    const excludedSourceFiles = new Set(['tasks.js', 'Gruntfile.js', 'gulpfile.js']);
 
     // Exact relative file paths (without leading slash) to exclude from dependency scanning
-    const excludedSourceRelPaths = new Set([ 'lib/tools.js' ]);
+    const excludedSourceRelPaths = new Set(['lib/tools.js']);
 
     const packageDependencies = context.packageJson.dependencies || {};
     const packageDevDependencies = context.packageJson.devDependencies || {};
@@ -1315,7 +1315,7 @@ async function checkCode (context) {
     const reportedDependencyIssues = new Set();
 
     for (const filePath of Object.keys(context)) {
-        if (!filePath.startsWith('/') || typeof context[ filePath ] !== 'string') {
+        if (!filePath.startsWith('/') || typeof context[filePath] !== 'string') {
             continue;
         }
 
@@ -1348,7 +1348,7 @@ async function checkCode (context) {
 
         common.debug(`Scanning "${filePath.slice(1)}" for dependencies`);
 
-        const imports = extractImports(context[ filePath ]);
+        const imports = extractImports(context[filePath]);
 
         for (const importTarget of imports) {
             common.debug(`  Found import: "${importTarget}"`);
@@ -1390,7 +1390,7 @@ async function checkCode (context) {
             }
 
             // Skip if package is listed in dependencies
-            if (packageDependencies[ packageName ]) {
+            if (packageDependencies[packageName]) {
                 continue;
             }
 
@@ -1400,17 +1400,17 @@ async function checkCode (context) {
             }
 
             // For @types/* packages, devDependencies is also acceptable
-            if (packageName.startsWith('@types/') && packageDevDependencies[ packageName ]) {
+            if (packageName.startsWith('@types/') && packageDevDependencies[packageName]) {
                 continue;
             }
 
             // For @iobroker/types, devDependencies is also acceptable
-            if (packageName === '@iobroker/types' && packageDevDependencies[ '@iobroker/types' ]) {
+            if (packageName === '@iobroker/types' && packageDevDependencies['@iobroker/types']) {
                 continue;
             }
 
             // @types/iobroker in devDependencies is an acceptable alternative for @iobroker/types
-            if (packageName === '@iobroker/types' && packageDevDependencies[ '@types/iobroker' ]) {
+            if (packageName === '@iobroker/types' && packageDevDependencies['@types/iobroker']) {
                 continue;
             }
 

--- a/lib/M5000_Code.js
+++ b/lib/M5000_Code.js
@@ -106,9 +106,10 @@ function getAllFiles (context, dirPath, root, filesList) {
                 filesList = getAllFiles(context, path.join(dirPath, file), [ root, file ].join('/'), filesList);
             }
         } else {
-            filesList.push([ root, file ].join('/').slice(1));
-            if (context.readFiles && context.readFiles.includes([ root, file ].join('/').slice(1))) {
-                context[ [ root, file ].join('/') ] = fs.readFileSync(path.join(dirPath, file), 'utf8');
+            const filePath = [ root, file ].join('/');
+            filesList.push(filePath);
+            if (context.readFiles && context.readFiles.includes(filePath)) {
+                context[ filePath ] = fs.readFileSync(path.join(dirPath, file), 'utf8');
             }
         }
     });

--- a/lib/M5000_Code.js
+++ b/lib/M5000_Code.js
@@ -18,7 +18,7 @@ const common = require('./common.js');
 const M5500__jsonConfig = require('./M5500__JsonConfig.js');
 
 // YAML file extensions for validation
-const yamlExtensions = ['.yml', '.yaml'];
+const yamlExtensions = [ '.yml', '.yaml' ];
 
 // Known Node.js built-in modules (can be used with node: prefix)
 const NODE_BUILT_INS = new Set([
@@ -67,26 +67,26 @@ const NODE_BUILT_INS = new Set([
 ]);
 
 // utility to parse words.js
-function extractWords(words) {
+function extractWords (words) {
     try {
         const lines = words.split(/\r\n|\r|\n/g);
         let i = 0;
-        while (!lines[i].match(/^systemDictionary = {/)) {
+        while (!lines[ i ].match(/^systemDictionary = {/)) {
             i++;
         }
         lines.splice(0, i);
 
         // remove last empty lines
         i = lines.length - 1;
-        while (!lines[i]) {
+        while (!lines[ i ]) {
             i--;
         }
         if (i < lines.length - 1) {
             lines.splice(i + 1);
         }
 
-        lines[0] = lines[0].replace('systemDictionary = ', '');
-        lines[lines.length - 1] = lines[lines.length - 1].trim().replace(/};$/, '}');
+        lines[ 0 ] = lines[ 0 ].replace('systemDictionary = ', '');
+        lines[ lines.length - 1 ] = lines[ lines.length - 1 ].trim().replace(/};$/, '}');
         words = lines.join('\n');
         const resultFunc = new Function(`return ${words};`);
 
@@ -96,19 +96,19 @@ function extractWords(words) {
     }
 }
 
-function getAllFiles(context, dirPath, root, filesList) {
-    const skipDirectories = ['.dev-server', 'node_modules', '.git', '.vscode'];
+function getAllFiles (context, dirPath, root, filesList) {
+    const skipDirectories = [ '.dev-server', 'node_modules', '.git', '.vscode' ];
     const files = fs.readdirSync(dirPath);
     filesList = filesList || [];
     files.forEach(file => {
         if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
             if (!skipDirectories.includes(file)) {
-                filesList = getAllFiles(context, path.join(dirPath, file), [root, file].join('/'), filesList);
+                filesList = getAllFiles(context, path.join(dirPath, file), [ root, file ].join('/'), filesList);
             }
         } else {
-            filesList.push([root, file].join('/').slice(1));
-            if (context.readFiles.includes([root, file].join('/').slice(1))) {
-                context[[root, file].join('/')] = fs.readFileSync(path.join(dirPath, file), 'utf8');
+            filesList.push([ root, file ].join('/').slice(1));
+            if (context.readFiles && context.readFiles.includes([ root, file ].join('/').slice(1))) {
+                context[ [ root, file ].join('/') ] = fs.readFileSync(path.join(dirPath, file), 'utf8');
             }
         }
     });
@@ -124,7 +124,7 @@ function getAllFiles(context, dirPath, root, filesList) {
  * @param {string} targetKey - The key to search for
  * @returns {boolean} true if the key is found anywhere in the object
  */
-function hasKeyInObject(obj, targetKey) {
+function hasKeyInObject (obj, targetKey) {
     if (typeof obj !== 'object' || obj === null) {
         return false;
     }
@@ -142,19 +142,19 @@ function hasKeyInObject(obj, targetKey) {
  * @param {string} key - The config key to check (e.g. 'option1')
  * @returns {boolean} true if the key is referenced in any admin UI file
  */
-function isKeyUsedInAdminConfig(context, key) {
-    if (context['/admin/index.html'] && context['/admin/index.html'].includes(key)) {
+function isKeyUsedInAdminConfig (context, key) {
+    if (context[ '/admin/index.html' ] && context[ '/admin/index.html' ].includes(key)) {
         return true;
     }
-    if (context['/admin/index_m.html'] && context['/admin/index_m.html'].includes(key)) {
+    if (context[ '/admin/index_m.html' ] && context[ '/admin/index_m.html' ].includes(key)) {
         return true;
     }
-    const jsonConfigRaw = context['/admin/jsonConfig.json'] || context['/admin/jsonConfig.json5'];
+    const jsonConfigRaw = context[ '/admin/jsonConfig.json' ] || context[ '/admin/jsonConfig.json5' ];
     if (jsonConfigRaw) {
         try {
-            const parsed = context['/admin/jsonConfig.json']
-                ? JSON.parse(context['/admin/jsonConfig.json'])
-                : JSON5.parse(context['/admin/jsonConfig.json5']);
+            const parsed = context[ '/admin/jsonConfig.json' ]
+                ? JSON.parse(context[ '/admin/jsonConfig.json' ])
+                : JSON5.parse(context[ '/admin/jsonConfig.json5' ]);
             if (hasKeyInObject(parsed, key)) {
                 return true;
             }
@@ -173,14 +173,14 @@ function isKeyUsedInAdminConfig(context, key) {
  * @param {string} importPath - The raw import path
  * @returns {string} The base package name
  */
-function extractPackageName(importPath) {
+function extractPackageName (importPath) {
     if (importPath.startsWith('@')) {
         // Scoped package: @scope/name/... -> @scope/name
         const parts = importPath.split('/');
         return parts.slice(0, 2).join('/');
     }
     // Regular package: name/... -> name
-    return importPath.split('/')[0];
+    return importPath.split('/')[ 0 ];
 }
 
 /**
@@ -191,7 +191,7 @@ function extractPackageName(importPath) {
  * @param {string} content - Source file content
  * @returns {string} Content with comments removed
  */
-function stripComments(content) {
+function stripComments (content) {
     // Remove block comments (/* ... */)
     let result = content.replace(/\/\*[\s\S]*?\*\//g, '');
     // Remove single-line comments (// ...)
@@ -205,7 +205,7 @@ function stripComments(content) {
  * @param {string} content - File content
  * @returns {string[]} Array of unique import targets
  */
-function extractImports(content) {
+function extractImports (content) {
     const imports = new Set();
 
     // Strip comments first to avoid matching require/import patterns inside comments
@@ -215,8 +215,8 @@ function extractImports(content) {
     const requirePattern = /\brequire\s*\(\s*['"`]([^'"`\n]+)['"`]\s*\)/g;
     let match;
     while ((match = requirePattern.exec(code)) !== null) {
-        common.debug(`    require:     found ${match[1]}`);
-        imports.add(match[1]);
+        common.debug(`    require:     found ${match[ 1 ]}`);
+        imports.add(match[ 1 ]);
     }
 
     // import ... from '...' (handles multi-line imports too)
@@ -230,28 +230,28 @@ function extractImports(content) {
     // `import type { Foo } from 'pkg'` which do not require runtime dependencies.
     const fromPattern = /\b(?:import)\b(?!\s*\()(?!\s+type\b)[\s\S]*?\bfrom\s+['"`]([^'"`\n]+)['"`]/g;
     while ((match = fromPattern.exec(code)) !== null) {
-        common.debug(`    import from: found ${match[1]}`);
-        imports.add(match[1]);
+        common.debug(`    import from: found ${match[ 1 ]}`);
+        imports.add(match[ 1 ]);
     }
 
     // Side-effect imports: import 'package'
     const sideEffectImportPattern = /\bimport\s+['"`]([^'"`\n]+)['"`]/g;
     while ((match = sideEffectImportPattern.exec(code)) !== null) {
-        common.debug(`    import ...:  found ${match[1]}`);
-        imports.add(match[1]);
+        common.debug(`    import ...:  found ${match[ 1 ]}`);
+        imports.add(match[ 1 ]);
     }
 
     // dynamic import('...')
     const dynamicImportPattern = /\bimport\s*\(\s*['"`]([^'"`\n]+)['"`]\s*\)/g;
     while ((match = dynamicImportPattern.exec(code)) !== null) {
-        common.debug(`    dyn import:  found ${match[1]}`);
-        imports.add(match[1]);
+        common.debug(`    dyn import:  found ${match[ 1 ]}`);
+        imports.add(match[ 1 ]);
     }
 
-    return [...imports];
+    return [ ...imports ];
 }
 
-async function checkCode(context) {
+async function checkCode (context) {
     console.log('\n[E5000 - E5999] checkCode');
 
     const readFiles = [
@@ -300,8 +300,8 @@ async function checkCode(context) {
     }
 
     // Add all executable files (.js, .mjs, .cjs, .ts) to readFiles, excluding certain directories
-    const executableExtensions = ['.js', '.mjs', '.cjs', '.ts'];
-    const excludeDirsForExecutables = ['node_modules', 'admin', 'admin-src', '.git', '.vscode', '.dev-server'];
+    const executableExtensions = [ '.js', '.mjs', '.cjs', '.ts' ];
+    const excludeDirsForExecutables = [ 'node_modules', 'admin', 'admin-src', '.git', '.vscode', '.dev-server' ];
 
     tempFilesList.forEach(filePath => {
         // Skip files in excluded directories
@@ -321,7 +321,7 @@ async function checkCode(context) {
     });
 
     // Add all YAML files (.yml, .yaml) to readFiles for validation
-    const excludeDirsForYaml = ['node_modules', '.git', '.vscode', '.dev-server'];
+    const excludeDirsForYaml = [ 'node_modules', '.git', '.vscode', '.dev-server' ];
 
     tempFilesList.forEach(filePath => {
         // Skip files in excluded directories
@@ -388,7 +388,7 @@ async function checkCode(context) {
 
             if (readFiles.includes(fileName)) {
                 common.debug(`    reading ${fileName}`);
-                context[fileName] = await common.getFile(context, fileName);
+                context[ fileName ] = await common.getFile(context, fileName);
             }
         }
     }
@@ -409,14 +409,14 @@ async function checkCode(context) {
     // W5041: Check i18n translation files for example keys (option1/option2).
     // Only raise warning if the keys are not actually used in admin UI files (index.html, index_m.html, or jsonConfig).
     if (!context.hasExampleConfigWarning) {
-        const exampleKeys = ['option1', 'option2'];
+        const exampleKeys = [ 'option1', 'option2' ];
         const foundI18nKeys = new Set();
         const foundI18nLangs = new Set();
         for (const lang of context.cfg.allowedLanguages) {
-            for (const i18nPath of [`/admin/i18n/${lang}/translations.json`, `/admin/i18n/${lang}.json`]) {
-                if (context[i18nPath]) {
+            for (const i18nPath of [ `/admin/i18n/${lang}/translations.json`, `/admin/i18n/${lang}.json` ]) {
+                if (context[ i18nPath ]) {
                     try {
-                        const i18nContent = JSON.parse(context[i18nPath]);
+                        const i18nContent = JSON.parse(context[ i18nPath ]);
                         const unusedI18nKeys = exampleKeys.filter(
                             key =>
                                 Object.prototype.hasOwnProperty.call(i18nContent, key) &&
@@ -435,8 +435,8 @@ async function checkCode(context) {
             }
         }
         if (foundI18nKeys.size) {
-            const keyList = [...foundI18nKeys].join(', ');
-            const langList = [...foundI18nLangs].join(', ');
+            const keyList = [ ...foundI18nKeys ].join(', ');
+            const langList = [ ...foundI18nLangs ].join(', ');
             context.warnings.push(
                 `[W5041] Example configuration (${keyList}) found in i18n translation files (${langList}). Please remove example configuration from your code.`,
             );
@@ -446,7 +446,7 @@ async function checkCode(context) {
 
     // Check for conflicting JavaScript file extensions in the same directory
     // W5034: Files with the same base name but different extensions (.ts, .js, .cjs, .mjs) in the same directory
-    const jsExtensions = ['.ts', '.js', '.cjs', '.mjs'];
+    const jsExtensions = [ '.ts', '.js', '.cjs', '.mjs' ];
     const filesByDirectory = new Map();
 
     // Group files by directory and base name
@@ -486,7 +486,7 @@ async function checkCode(context) {
 
     // Check for conflicting JSON file extensions in the same directory
     // E5038: Files with the same base name but different extensions (.json, .json5) in the same directory
-    const jsonExtensions = ['.json', '.json5'];
+    const jsonExtensions = [ '.json', '.json5' ];
     const jsonFilesByDirectory = new Map();
 
     // Group files by directory and base name
@@ -528,14 +528,14 @@ async function checkCode(context) {
     // Check all YAML files (.yml, .yaml) for valid syntax
     // E5035: YAML file cannot be parsed
     for (const fileName of Object.keys(context)) {
-        if (fileName.startsWith('/') && typeof context[fileName] === 'string') {
+        if (fileName.startsWith('/') && typeof context[ fileName ] === 'string') {
             const ext = path.extname(fileName);
             if (yamlExtensions.includes(ext)) {
                 try {
-                    yaml.load(context[fileName]);
+                    yaml.load(context[ fileName ]);
                 } catch (e) {
                     context.errors.push(
-                        `[E5035] Cannot parse YAML file "${fileName.slice(1)}": ${e.message.split('\n')[0]}`,
+                        `[E5035] Cannot parse YAML file "${fileName.slice(1)}": ${e.message.split('\n')[ 0 ]}`,
                     );
                 }
             }
@@ -545,55 +545,55 @@ async function checkCode(context) {
     let usesReact = false;
     if (
         context.packageJson.devDependencies &&
-        (context.packageJson.devDependencies['@iobroker/adapter-react-v5'] ||
-            context.packageJson.devDependencies['react'])
+        (context.packageJson.devDependencies[ '@iobroker/adapter-react-v5' ] ||
+            context.packageJson.devDependencies[ 'react' ])
     ) {
         common.info('REACT detected at package devDependencies');
         usesReact = true;
     }
     if (
         context.packageJson.dependencies &&
-        (context.packageJson.dependencies['@iobroker/adapter-react-v5'] || context.packageJson.dependencies['react'])
+        (context.packageJson.dependencies[ '@iobroker/adapter-react-v5' ] || context.packageJson.dependencies[ 'react' ])
     ) {
         common.info('REACT detected at package dependencies');
         usesReact = true;
     }
-    if (context['/src-admin/package.json']) {
-        const packageJson = JSON.parse(context['/src-admin/package.json']);
-        if (packageJson.devDependencies && packageJson.devDependencies['@iobroker/adapter-react-v5']) {
+    if (context[ '/src-admin/package.json' ]) {
+        const packageJson = JSON.parse(context[ '/src-admin/package.json' ]);
+        if (packageJson.devDependencies && packageJson.devDependencies[ '@iobroker/adapter-react-v5' ]) {
             common.info('REACT detected at src-admin/package devDependencies');
             usesReact = true;
         }
-        if (packageJson.dependencies && packageJson.dependencies['@iobroker/adapter-react-v5']) {
+        if (packageJson.dependencies && packageJson.dependencies[ '@iobroker/adapter-react-v5' ]) {
             common.info('REACT detected at src-admin/package dependencies');
             usesReact = true;
         }
     }
-    if (context['/src-widgets/package.json']) {
-        const packageJson = JSON.parse(context['/src-widgets/package.json']);
+    if (context[ '/src-widgets/package.json' ]) {
+        const packageJson = JSON.parse(context[ '/src-widgets/package.json' ]);
         if (
             packageJson.devDependencies &&
-            (packageJson.devDependencies['@iobroker/adapter-react-v5'] || packageJson.devDependencies['react'])
+            (packageJson.devDependencies[ '@iobroker/adapter-react-v5' ] || packageJson.devDependencies[ 'react' ])
         ) {
             common.info('REACT detected at src-widgets/package devDependencies');
             usesReact = true;
         }
         if (
             packageJson.dependencies &&
-            (packageJson.dependencies['@iobroker/adapter-react-v5'] || packageJson.dependencies['react'])
+            (packageJson.dependencies[ '@iobroker/adapter-react-v5' ] || packageJson.dependencies[ 'react' ])
         ) {
             common.info('REACT detected at src-widgets/package dependencies');
             usesReact = true;
         }
     }
-    if (context['/src/package.json']) {
+    if (context[ '/src/package.json' ]) {
         //console.log('"src/package.json" exists');
-        const packageJson = JSON.parse(context['/src/package.json']);
-        if (packageJson.devDependencies && packageJson.devDependencies['@iobroker/adapter-react-v5']) {
+        const packageJson = JSON.parse(context[ '/src/package.json' ]);
+        if (packageJson.devDependencies && packageJson.devDependencies[ '@iobroker/adapter-react-v5' ]) {
             // console.log('REACT detected');
             usesReact = true;
         }
-        if (packageJson.dependencies && packageJson.dependencies['@iobroker/adapter-react-v5']) {
+        if (packageJson.dependencies && packageJson.dependencies[ '@iobroker/adapter-react-v5' ]) {
             // console.log('REACT detected');
             usesReact = true;
         }
@@ -614,30 +614,30 @@ async function checkCode(context) {
         (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.config === 'materialize')
     ) {
         if (
-            context['/admin/index_m.html'] &&
-            context['/admin/index_m.html'].includes('selectID.js') &&
+            context[ '/admin/index_m.html' ] &&
+            context[ '/admin/index_m.html' ].includes('selectID.js') &&
             !context.filesList.includes('/admin/img/info-big.png')
         ) {
             context.errors.push('[E5002] "/admin/img/info-big.png" not found, but selectID.js used in index_m.html ');
         }
 
-        if (context['/admin/words.js']) {
+        if (context[ '/admin/words.js' ]) {
             // at least 3 languages must be in
-            const words = extractWords(context['/admin/words.js']);
+            const words = extractWords(context[ '/admin/words.js' ]);
             if (words) {
-                const problem = Object.keys(words).filter(word => !words[word].de || !words[word].ru);
+                const problem = Object.keys(words).filter(word => !words[ word ].de || !words[ word ].ru);
                 if (problem.length > 3) {
                     context.errors.push(
                         `[E5006] More non translated in german or russian words found in admin/words.js. You can use https://translator.iobroker.in/ for translations`,
                     );
                 } else {
                     problem.forEach(word => {
-                        if (!words[word].de) {
+                        if (!words[ word ].de) {
                             context.errors.push(
                                 `[E5006] Word "${word}" is not translated to german in admin/words.js. You can use https://translator.iobroker.in/ for translations`,
                             );
                         }
-                        if (!words[word].ru) {
+                        if (!words[ word ].ru) {
                             context.errors.push(
                                 `[E5006] Word "${word}" is not translated to russian in admin/words.js. You can use https://translator.iobroker.in/ for translations`,
                             );
@@ -652,34 +652,34 @@ async function checkCode(context) {
 
     if (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.config === 'json') {
         let jsonConfig;
-        if (context['/admin/jsonConfig.json'] || context['/admin/jsonConfig.json5']) {
+        if (context[ '/admin/jsonConfig.json' ] || context[ '/admin/jsonConfig.json5' ]) {
             try {
-                jsonConfig = context['/admin/jsonConfig.json']
-                    ? JSON.parse(context['/admin/jsonConfig.json'])
-                    : JSON5.parse(context['/admin/jsonConfig.json5']);
+                jsonConfig = context[ '/admin/jsonConfig.json' ]
+                    ? JSON.parse(context[ '/admin/jsonConfig.json' ])
+                    : JSON5.parse(context[ '/admin/jsonConfig.json5' ]);
             } catch (e) {
                 context.errors.push(
-                    `[E5007] Cannot parse "/admin/jsonConfig.json${context['/admin/jsonConfig.json'] ? '' : '5'}": ${e}`,
+                    `[E5007] Cannot parse "/admin/jsonConfig.json${context[ '/admin/jsonConfig.json' ] ? '' : '5'}": ${e}`,
                 );
             }
         } else {
             context.errors.push(
-                `[E5008] "admin/jsonConfig.json${context['/admin/jsonConfig.json'] ? '' : '5'}" not found, but admin support is declared`,
+                `[E5008] "admin/jsonConfig.json${context[ '/admin/jsonConfig.json' ] ? '' : '5'}" not found, but admin support is declared`,
             );
         }
 
         if (jsonConfig) {
             if (jsonConfig.i18n === true) {
                 context.cfg.allowedLanguages.forEach(lang => {
-                    if (context[`/admin/i18n/${lang}/translations.json`]) {
+                    if (context[ `/admin/i18n/${lang}/translations.json` ]) {
                         try {
-                            JSON.parse(context[`/admin/i18n/${lang}/translations.json`]);
+                            JSON.parse(context[ `/admin/i18n/${lang}/translations.json` ]);
                         } catch (e) {
                             context.errors.push(`[E5009] Cannot parse "admin/i18n/${lang}/translations.json": ${e}`);
                         }
-                    } else if (context[`/admin/i18n/${lang}.json`]) {
+                    } else if (context[ `/admin/i18n/${lang}.json` ]) {
                         try {
-                            JSON.parse(context[`/admin/i18n/${lang}.json`]);
+                            JSON.parse(context[ `/admin/i18n/${lang}.json` ]);
                         } catch (e) {
                             context.errors.push(`[E5009] Cannot parse "admin/i18n/${lang}.json": ${e}`);
                         }
@@ -697,7 +697,7 @@ async function checkCode(context) {
 
             M5500__jsonConfig.checkJsonConfig(
                 context,
-                `admin/jsonConfig.json${context['/admin/jsonConfig.json'] ? '' : '5'}`,
+                `admin/jsonConfig.json${context[ '/admin/jsonConfig.json' ] ? '' : '5'}`,
                 jsonConfig,
             );
         } // if (jsonConfig) ...
@@ -721,8 +721,8 @@ async function checkCode(context) {
             '/.create-adapter.json',
         ];
         for (const fileName of Object.keys(context)) {
-            if (fileName.startsWith('/') && typeof context[fileName] === 'string' && !excludeFiles.includes(fileName)) {
-                const content = context[fileName];
+            if (fileName.startsWith('/') && typeof context[ fileName ] === 'string' && !excludeFiles.includes(fileName)) {
+                const content = context[ fileName ];
                 // Detect references to words.js in various forms:
                 // - Direct file name: words.js (e.g. in HTML script tags)
                 // - Path-prefixed: ./words, ../words, admin/words (with or without .js extension)
@@ -773,7 +773,7 @@ async function checkCode(context) {
         context.ioPackageJson.common.adminUI.config === 'json' &&
         (context.filesList.includes('/admin/jsonConfig.json') || context.filesList.includes('/admin/jsonConfig.json5'))
     ) {
-        const obsoleteFiles = ['/admin/index.html', '/admin/index_m.html', '/admin/style.css'];
+        const obsoleteFiles = [ '/admin/index.html', '/admin/index_m.html', '/admin/style.css' ];
         for (const file of obsoleteFiles) {
             if (context.filesList.includes(file)) {
                 context.warnings.push(
@@ -788,37 +788,37 @@ async function checkCode(context) {
         context.ioPackageJson.common.jsonCustom ||
         (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.custom === 'json')
     ) {
-        if (context['/admin/jsonCustom.json'] || context['/admin/jsonCustom.json5']) {
+        if (context[ '/admin/jsonCustom.json' ] || context[ '/admin/jsonCustom.json5' ]) {
             try {
-                context['/admin/jsonCustom.json']
-                    ? JSON.parse(context['/admin/jsonCustom.json'])
-                    : JSON5.parse(context['/admin/jsonCustom.json5']);
+                context[ '/admin/jsonCustom.json' ]
+                    ? JSON.parse(context[ '/admin/jsonCustom.json' ])
+                    : JSON5.parse(context[ '/admin/jsonCustom.json5' ]);
             } catch (e) {
                 context.errors.push(
-                    `[E5011] Cannot parse "/admin/jsonCustom.json${context['/admin/jsonCustom.json'] ? '' : '5'}": ${e}`,
+                    `[E5011] Cannot parse "/admin/jsonCustom.json${context[ '/admin/jsonCustom.json' ] ? '' : '5'}": ${e}`,
                 );
             }
         } else {
             context.errors.push(
-                `[E5012] "/admin/jsonCustom.json${context['/admin/jsonCustom.json'] ? '' : '5'}" not found, but custom support is declared`,
+                `[E5012] "/admin/jsonCustom.json${context[ '/admin/jsonCustom.json' ] ? '' : '5'}" not found, but custom support is declared`,
             );
         }
     }
 
     if (context.ioPackageJson.common.adminUI && context.ioPackageJson.common.adminUI.tab === 'json') {
-        if (context['/admin/jsonTab.json'] || context['/admin/jsonTab.json5']) {
+        if (context[ '/admin/jsonTab.json' ] || context[ '/admin/jsonTab.json5' ]) {
             try {
-                context['/admin/jsonTab.json']
-                    ? JSON.parse(context['/admin/jsonTab.json'])
-                    : JSON5.parse(context['/admin/jsonTab.json5']);
+                context[ '/admin/jsonTab.json' ]
+                    ? JSON.parse(context[ '/admin/jsonTab.json' ])
+                    : JSON5.parse(context[ '/admin/jsonTab.json5' ]);
             } catch (e) {
                 context.errors.push(
-                    `[E5044] Cannot parse "/admin/jsonTab.json${context['/admin/jsonTab.json'] ? '' : '5'}": ${e}`,
+                    `[E5044] Cannot parse "/admin/jsonTab.json${context[ '/admin/jsonTab.json' ] ? '' : '5'}": ${e}`,
                 );
             }
         } else {
             context.errors.push(
-                `[E5045] "/admin/jsonTab.json${context['/admin/jsonTab.json'] ? '' : '5'}" not found, but tab support is declared`,
+                `[E5045] "/admin/jsonTab.json${context[ '/admin/jsonTab.json' ] ? '' : '5'}" not found, but tab support is declared`,
             );
         }
     }
@@ -834,12 +834,12 @@ async function checkCode(context) {
     ];
 
     for (const configFile of jsonConfigFilesToValidate) {
-        if (context[configFile]) {
+        if (context[ configFile ]) {
             let parsed;
             try {
                 parsed = configFile.endsWith('.json5')
-                    ? JSON5.parse(context[configFile])
-                    : JSON.parse(context[configFile]);
+                    ? JSON5.parse(context[ configFile ])
+                    : JSON.parse(context[ configFile ]);
             } catch (e) {
                 common.debug(`Could not parse ${configFile} for schema validation: ${e.message}`);
                 context.warnings.push(
@@ -852,7 +852,7 @@ async function checkCode(context) {
         }
     }
 
-    if (context.ioPackageJson.common.blockly && !context['/admin/blockly.js']) {
+    if (context.ioPackageJson.common.blockly && !context[ '/admin/blockly.js' ]) {
         context.errors.push('[E5014] "/admin/blockly.js" not found, but blockly support is declared');
     }
 
@@ -869,7 +869,7 @@ async function checkCode(context) {
         }
     }
 
-    const forbiddenFiles = ['/iob_npm.done', '/iob', '/iobroker'];
+    const forbiddenFiles = [ '/iob_npm.done', '/iob', '/iobroker' ];
 
     forbiddenFiles.forEach(file => {
         if (context.filesList.includes(file)) {
@@ -883,18 +883,18 @@ async function checkCode(context) {
         );
     }
 
-    if (context['/.travis.yml']) {
+    if (context[ '/.travis.yml' ]) {
         context.hasTravis = true;
     }
 
-    if (context['/gulpfile.js']) {
-        if (!context.packageJson.devDependencies['gulp']) {
+    if (context[ '/gulpfile.js' ]) {
+        if (!context.packageJson.devDependencies[ 'gulp' ]) {
             context.warnings.push(
                 '[W5020] "gulpfile.js" found in repo but "gulp" not found at devDependencies at package.json. Check whether it can be removed.',
             );
         } else if (!usesReact) {
             // Check if @iobroker/adapter-dev is present in devDependencies
-            if (context.packageJson.devDependencies && context.packageJson.devDependencies['@iobroker/adapter-dev']) {
+            if (context.packageJson.devDependencies && context.packageJson.devDependencies[ '@iobroker/adapter-dev' ]) {
                 context.warnings.push(
                     '[S5031] "gulpfile.js" found in repo while @iobroker/adapter-dev already used. Please check if gulp is still needed.',
                 );
@@ -905,7 +905,7 @@ async function checkCode(context) {
             }
         }
     } else {
-        if (context.packageJson.devDependencies['gulp']) {
+        if (context.packageJson.devDependencies[ 'gulp' ]) {
             context.warnings.push(
                 '[W5021] "gulp" found at devDependencies at package.json but no "gulpfile.js" found. Is this dependency really required?',
             );
@@ -913,7 +913,7 @@ async function checkCode(context) {
     }
 
     // W5048: Check for obsolete eslint/prettier config files when @iobroker/eslint-config is used
-    if (context.packageJson.devDependencies && context.packageJson.devDependencies['@iobroker/eslint-config']) {
+    if (context.packageJson.devDependencies && context.packageJson.devDependencies[ '@iobroker/eslint-config' ]) {
         const obsoleteFiles = [
             '/.eslintignore',
             '/.eslintrc.json',
@@ -930,17 +930,17 @@ async function checkCode(context) {
         }
     }
 
-    if (context.packageJson.devDependencies && context.packageJson.devDependencies['@alcalzone/release-script']) {
-        const version = context.packageJson.devDependencies['@alcalzone/release-script'];
+    if (context.packageJson.devDependencies && context.packageJson.devDependencies[ '@alcalzone/release-script' ]) {
+        const version = context.packageJson.devDependencies[ '@alcalzone/release-script' ];
         if (compareVersions.compareVersions(version, '3.0.0') >= 0) {
-            if (!context['/.releaseconfig.json']) {
+            if (!context[ '/.releaseconfig.json' ]) {
                 context.errors.push(
                     '[E5018] "@alcalzone/release-script" (>=3.0.0) is used, but ".releaseconfig.json" not found. Please create.',
                 );
             } else {
-                common.debug(`context[/.releaseconfig.json: ${context['/.releaseconfig.json']}`);
+                common.debug(`context[/.releaseconfig.json: ${context[ '/.releaseconfig.json' ]}`);
                 try {
-                    const releaseConfigJson = JSON.parse(context['/.releaseconfig.json']);
+                    const releaseConfigJson = JSON.parse(context[ '/.releaseconfig.json' ]);
                     common.debug(`releaseConfigJson: ${releaseConfigJson}`);
 
                     const plugins = releaseConfigJson.plugins || [];
@@ -959,22 +959,22 @@ async function checkCode(context) {
                     };
 
                     // Required plugins for ioBroker adapters
-                    const requiredPlugins = ['iobroker', 'license'];
+                    const requiredPlugins = [ 'iobroker', 'license' ];
                     // Suggested plugins for ioBroker adapters
-                    const suggestedPlugins = ['manual-review'];
+                    const suggestedPlugins = [ 'manual-review' ];
 
                     // Check required plugins are installed as devDependencies
-                    if (!context.packageJson.devDependencies['@alcalzone/release-script-plugin-iobroker']) {
+                    if (!context.packageJson.devDependencies[ '@alcalzone/release-script-plugin-iobroker' ]) {
                         context.errors.push(
                             '[E5024] "@alcalzone/release-script" requires plugin "@alcalzone/release-script-plugin-iobroker". Please add.',
                         );
                     }
-                    if (!context.packageJson.devDependencies['@alcalzone/release-script-plugin-license']) {
+                    if (!context.packageJson.devDependencies[ '@alcalzone/release-script-plugin-license' ]) {
                         context.errors.push(
                             '[E5025] "@alcalzone/release-script" requires plugin "@alcalzone/release-script-plugin-license". Please add.',
                         );
                     }
-                    if (!context.packageJson.devDependencies['@alcalzone/release-script-plugin-manual-review']) {
+                    if (!context.packageJson.devDependencies[ '@alcalzone/release-script-plugin-manual-review' ]) {
                         context.warnings.push(
                             '[S5026] Consider adding plugin "@alcalzone/release-script-plugin-manual-review".',
                         );
@@ -982,8 +982,8 @@ async function checkCode(context) {
 
                     // Check all plugins listed in .releaseconfig.json are installed as devDependencies
                     for (const plugin of plugins) {
-                        const packageName = pluginToPackage[plugin];
-                        if (packageName && !context.packageJson.devDependencies[packageName]) {
+                        const packageName = pluginToPackage[ plugin ];
+                        if (packageName && !context.packageJson.devDependencies[ packageName ]) {
                             context.errors.push(
                                 `[E5036] Plugin "${plugin}" is listed at .releaseconfig.json but "${packageName}" is not installed as devDependency. Please add.`,
                             );
@@ -992,8 +992,8 @@ async function checkCode(context) {
 
                     // Check all installed plugin devDependencies are listed in .releaseconfig.json
                     for (const pluginName in pluginToPackage) {
-                        const packageName = pluginToPackage[pluginName];
-                        if (context.packageJson.devDependencies[packageName]) {
+                        const packageName = pluginToPackage[ pluginName ];
+                        if (context.packageJson.devDependencies[ packageName ]) {
                             if (!plugins.includes(pluginName)) {
                                 if (requiredPlugins.includes(pluginName)) {
                                     context.errors.push(
@@ -1019,7 +1019,7 @@ async function checkCode(context) {
     }
 
     if (context.packageJson.main && context.packageJson.main.endsWith('.js')) {
-        if (!context[`/${context.packageJson.main}`]) {
+        if (!context[ `/${context.packageJson.main}` ]) {
             if (!context.ioPackageJson.common.nogit) {
                 context.errors.push(
                     `[E5019] "${context.packageJson.main}" found in package.json, but not found as file`,
@@ -1027,8 +1027,8 @@ async function checkCode(context) {
             }
         } else {
             if (
-                context[`/${context.packageJson.main}`].includes('setInterval(') &&
-                !context[`/${context.packageJson.main}`].includes('clearInterval(')
+                context[ `/${context.packageJson.main}` ].includes('setInterval(') &&
+                !context[ `/${context.packageJson.main}` ].includes('clearInterval(')
             ) {
                 if (context.ioPackageJson.common.compact) {
                     // if compact mode supported, it is critical
@@ -1042,8 +1042,8 @@ async function checkCode(context) {
                 }
             }
             if (
-                context[`/${context.packageJson.main}`].includes('setTimeout(') &&
-                !context[`/${context.packageJson.main}`].includes('clearTimeout(')
+                context[ `/${context.packageJson.main}` ].includes('setTimeout(') &&
+                !context[ `/${context.packageJson.main}` ].includes('clearTimeout(')
             ) {
                 if (context.ioPackageJson.common.compact) {
                     // if compact mode supported, it is critical
@@ -1067,8 +1067,8 @@ async function checkCode(context) {
 
         // Search through all loaded files for references to tools.js
         for (const fileName of Object.keys(context)) {
-            if (fileName.startsWith('/') && typeof context[fileName] === 'string') {
-                const content = context[fileName];
+            if (fileName.startsWith('/') && typeof context[ fileName ] === 'string') {
+                const content = context[ fileName ];
                 // Look for various patterns that might reference lib/tools.js
                 if (
                     content.includes('lib/tools') ||
@@ -1110,7 +1110,7 @@ async function checkCode(context) {
      * @param {number} lineIndex - Current line index being checked
      * @returns {boolean} True if the line is within an adapter class context
      */
-    function isInAdapterClassContext(lines, lineIndex) {
+    function isInAdapterClassContext (lines, lineIndex) {
         // Look backwards and forwards to understand the context
         // const contextRange = 50; // Look within 50 lines for class context
         const contextRange = 1000; // Look within 1000 lines for class context
@@ -1119,7 +1119,7 @@ async function checkCode(context) {
 
         // Check for class that extends utils.Adapter pattern
         for (let i = startIdx; i < endIdx; i++) {
-            const line = lines[i].trim();
+            const line = lines[ i ].trim();
 
             // Pattern 1: class SomeClass extends utils.Adapter
             if (/class\s+\w+\s+extends\s+utils\.Adapter/i.test(line)) {
@@ -1129,7 +1129,7 @@ async function checkCode(context) {
                     let braceCount = 0;
                     let foundOpenBrace = false;
                     for (let j = i; j <= lineIndex; j++) {
-                        const checkLine = lines[j];
+                        const checkLine = lines[ j ];
                         for (const char of checkLine) {
                             if (char === '{') {
                                 braceCount++;
@@ -1158,7 +1158,7 @@ async function checkCode(context) {
                 let braceCount = 0;
                 let foundOpenBrace = false;
                 for (let j = i; j <= lineIndex; j++) {
-                    const checkLine = lines[j];
+                    const checkLine = lines[ j ];
                     for (const char of checkLine) {
                         if (char === '{') {
                             braceCount++;
@@ -1181,12 +1181,12 @@ async function checkCode(context) {
         }
 
         // Check if the method call is actually to a local function by looking for function definitions
-        const methodCallMatch = lines[lineIndex].match(/this\.(\w+)\s*\(/);
+        const methodCallMatch = lines[ lineIndex ].match(/this\.(\w+)\s*\(/);
         if (methodCallMatch) {
-            const methodName = methodCallMatch[1];
+            const methodName = methodCallMatch[ 1 ];
             // Look for local function definition of this method
             for (let i = 0; i < lines.length; i++) {
-                const line = lines[i].trim();
+                const line = lines[ i ].trim();
                 // Pattern: this.methodName = function or this.methodName = async function
                 if (new RegExp(`this\\.${methodName}\\s*=\\s*(async\\s+)?function`, 'i').test(line)) {
                     return false; // It's a local function, not adapter method
@@ -1202,7 +1202,7 @@ async function checkCode(context) {
 
     // Search through all loaded executable files for deprecated method usage
     for (const fileName of Object.keys(context)) {
-        if (fileName.startsWith('/') && typeof context[fileName] === 'string') {
+        if (fileName.startsWith('/') && typeof context[ fileName ] === 'string') {
             // Skip files in excluded directories (admin, tests, etc.)
             const pathParts = fileName.split('/').filter(part => part !== '');
             const isInExcludedDir = pathParts.some(part => excludeDirsForExecutables.includes(part));
@@ -1213,16 +1213,16 @@ async function checkCode(context) {
 
             // Only check executable files
             const ext = path.extname(fileName);
-            const executableExtensions = ['.js', '.mjs', '.cjs', '.ts'];
+            const executableExtensions = [ '.js', '.mjs', '.cjs', '.ts' ];
             if (!executableExtensions.includes(ext)) {
                 continue;
             }
 
-            const content = context[fileName];
+            const content = context[ fileName ];
             const lines = content.split(/\r\n|\r|\n/g);
 
             for (let i = 0; i < lines.length; i++) {
-                const line = lines[i];
+                const line = lines[ i ];
 
                 for (const method of deprecatedMethods) {
                     // Skip if this method has already been reported
@@ -1278,12 +1278,12 @@ async function checkCode(context) {
     }
 
     // Packages known to be provided by the js-controller/system and therefore not required as dependencies
-    const systemProvidedPackages = new Set(['@iobroker/plugin-sentry']);
+    const systemProvidedPackages = new Set([ '@iobroker/plugin-sentry' ]);
 
     // W5042/S5043: Scan source files for require/import statements and check dependencies
     // Exclude files in admin/, build/, doc/, src-admin/, admin-src/, test/ directories
     // and *.test.* and *.config.* files
-    const sourceFileExtensions = new Set(['.js', '.mjs', '.cjs', '.ts']);
+    const sourceFileExtensions = new Set([ '.js', '.mjs', '.cjs', '.ts' ]);
     const excludedSourceDirs = new Set([
         'admin',
         'build',
@@ -1302,10 +1302,10 @@ async function checkCode(context) {
         '.dev-server',
     ]);
     // Exact file base names to exclude from dependency scanning
-    const excludedSourceFiles = new Set(['tasks.js', 'Gruntfile.js', 'gulpfile.js']);
+    const excludedSourceFiles = new Set([ 'tasks.js', 'Gruntfile.js', 'gulpfile.js' ]);
 
     // Exact relative file paths (without leading slash) to exclude from dependency scanning
-    const excludedSourceRelPaths = new Set(['lib/tools.js']);
+    const excludedSourceRelPaths = new Set([ 'lib/tools.js' ]);
 
     const packageDependencies = context.packageJson.dependencies || {};
     const packageDevDependencies = context.packageJson.devDependencies || {};
@@ -1314,7 +1314,7 @@ async function checkCode(context) {
     const reportedDependencyIssues = new Set();
 
     for (const filePath of Object.keys(context)) {
-        if (!filePath.startsWith('/') || typeof context[filePath] !== 'string') {
+        if (!filePath.startsWith('/') || typeof context[ filePath ] !== 'string') {
             continue;
         }
 
@@ -1347,7 +1347,7 @@ async function checkCode(context) {
 
         common.debug(`Scanning "${filePath.slice(1)}" for dependencies`);
 
-        const imports = extractImports(context[filePath]);
+        const imports = extractImports(context[ filePath ]);
 
         for (const importTarget of imports) {
             common.debug(`  Found import: "${importTarget}"`);
@@ -1389,7 +1389,7 @@ async function checkCode(context) {
             }
 
             // Skip if package is listed in dependencies
-            if (packageDependencies[packageName]) {
+            if (packageDependencies[ packageName ]) {
                 continue;
             }
 
@@ -1399,17 +1399,17 @@ async function checkCode(context) {
             }
 
             // For @types/* packages, devDependencies is also acceptable
-            if (packageName.startsWith('@types/') && packageDevDependencies[packageName]) {
+            if (packageName.startsWith('@types/') && packageDevDependencies[ packageName ]) {
                 continue;
             }
 
             // For @iobroker/types, devDependencies is also acceptable
-            if (packageName === '@iobroker/types' && packageDevDependencies['@iobroker/types']) {
+            if (packageName === '@iobroker/types' && packageDevDependencies[ '@iobroker/types' ]) {
                 continue;
             }
 
             // @types/iobroker in devDependencies is an acceptable alternative for @iobroker/types
-            if (packageName === '@iobroker/types' && packageDevDependencies['@types/iobroker']) {
+            if (packageName === '@iobroker/types' && packageDevDependencies[ '@types/iobroker' ]) {
                 continue;
             }
 

--- a/lib/postprocessing.js
+++ b/lib/postprocessing.js
@@ -29,7 +29,7 @@ const mapSeverity4New = {
     W1032: 'E', // [W1032] Many "common.news" found in io-package.json
     W1034: 'E', // [W1034] Missing suggested translation into ru,pt,nl,fr,it,es,pl,uk,zh-cn of "common.desc"
     W1056: 'E', // [W1056] admin 7.6.17 listed as dependency but 7.6.20 is recommended.
-    W2007: 'E', // [W2007] Version 0.7.0-beta.2 is tagged as "latest" at npm 
+    W2007: 'E', // [W2007] Version 0.7.0-beta.2 is tagged as "latest" at npm
     W3009: 'E', // [W3009] Workflow "test-and-release.yml" is missing recommended concurrency configuration.
     W8915: 'E', // [W8915] Dependabot npm entry (directory: "/") has no "cooldown" configured.
     W8916: 'E', // [W8916] Dependabot configuration "/.github/dependabot.yml" has no entry with "package-ecosystem: github-actions".


### PR DESCRIPTION
- Guard context.readFiles access in getAllFiles() to fix
  "Cannot read properties of undefined (reading 'includes')"
  when checkCode() scans files before context.readFiles is assigned
- Exit with code 1 when errors are found, enabling CLI chaining
  e.g. npx @iobroker/repochecker repo --local && npm run release

## Summary

```bash
npx @iobroker/repochecker repo && echo "ok"
```
* "ok" is always printed, regardless of errors.
 
```bash
npx @iobroker/repochecker repo --local && echo "ok"
```
* "ok" is printed only if no errors were found.
