### PR TITLE
Skip E9007/W9008 tracked-but-gitignored check in --local mode (false positives)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Example:
 
 * (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.
 * (Copilot) Warn when tracked files or directories are still covered by `.gitignore` and error if a tracked `/build` directory is ignored.
+* (krobipd) Skip the E9007/W9008 tracked-but-gitignored check in `--local` mode, where the file list is a filesystem walk that includes gitignored build outputs and produces false positives.
 
 ### 5.19.12 (2026-07-13)
 

--- a/lib/M9000_GitNpmIgnore.js
+++ b/lib/M9000_GitNpmIgnore.js
@@ -14,7 +14,7 @@
     - conversion of github to regex is wrong with multiple stars
 */
 
-// const common = require('./common.js');
+const common = require('./common.js');
 const { minimatch } = require('minimatch');
 
 // Source directories (or directory paths) whose i18n subdirectories are excluded from npm packaging
@@ -330,17 +330,28 @@ async function checkGitIgnore(context) {
             );
         }
 
-        for (const entry of findIgnoredTrackedEntries(trackedEntries, rules)) {
-            if (entry.path === '/build' && entry.isDirectory) {
-                context.errors.push(
-                    '[E9007] build directory is tracked but excluded by .gitignore. Either remove the tracked /build directory from git (if generated) or remove the ignore rule (if intentionally tracked).',
-                );
-                continue;
-            }
+        // E9007/W9008 flag files that are BOTH tracked by git AND excluded by
+        // .gitignore. This can only be decided from the repository's committed
+        // file list. In remote mode `context.filesList` is exactly that (fetched
+        // from jsdelivr / the GitHub tree). In `--local` mode, however, it is a
+        // plain filesystem walk (`getAllFiles` in M5000_Code.js) that also
+        // contains build outputs and other gitignored-but-untracked files that
+        // merely exist on disk — so a match there is NOT proof of git-tracking
+        // and produces false positives (e.g. admin/custom, src-admin/build). Run
+        // this check only in remote mode, where the file list is authoritative.
+        if (!common.isLocal()) {
+            for (const entry of findIgnoredTrackedEntries(trackedEntries, rules)) {
+                if (entry.path === '/build' && entry.isDirectory) {
+                    context.errors.push(
+                        '[E9007] build directory is tracked but excluded by .gitignore. Either remove the tracked /build directory from git (if generated) or remove the ignore rule (if intentionally tracked).',
+                    );
+                    continue;
+                }
 
-            context.warnings.push(
-                `[W9008] ${entry.isDirectory ? 'directory' : 'file'} ${entry.path.replace(/^\//, '')} is tracked but covered by .gitignore. Remove from git if generated, or remove the ignore rule if intentionally tracked.`,
-            );
+                context.warnings.push(
+                    `[W9008] ${entry.isDirectory ? 'directory' : 'file'} ${entry.path.replace(/^\//, '')} is tracked but covered by .gitignore. Remove from git if generated, or remove the ignore rule if intentionally tracked.`,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Running the checker with `--local` reports **[W9008]** (and can report **[E9007]**) for files that are **not actually tracked by git** — a false positive.

In `--local` mode, `context.filesList` is built by `getAllFiles` (`lib/M5000_Code.js`), a plain filesystem walk of the working directory. That walk includes gitignored-but-untracked build outputs (`admin/custom`, `src-admin/build`, …). `findIgnoredTrackedEntries` in `M9000_GitNpmIgnore.js` then matches those against `.gitignore` and flags them as "tracked but covered by .gitignore" — but their mere presence on disk is **not** proof of git-tracking.

In remote mode this is correct, because there `filesList` is the authoritative committed file tree (fetched from jsdelivr / the GitHub tree).

## Fix

Guard the `findIgnoredTrackedEntries` loop with `!common.isLocal()`, matching the `!isLocal()` guard pattern already used in the codebase (e.g. `lib/common.js:251`). The E9007/W9008 check now runs only in remote mode, where the file list is authoritative; a genuinely tracked-and-gitignored file is still caught on the CI/remote run. (Also uncomments the already-present `require('./common.js')`.)

## Verification

Ran the patched checker with `--local --noinfo` against a real adapter (`iobroker.govee-smart`, which has gitignored `admin/custom` + `src-admin/build`): the previous W9008/E9007 false positives drop to **0**, all other findings unchanged. Remote-mode behaviour is untouched.

Related to #1075 (same class of issue: a check not accounting for `--local` mode).
