### PR TITLE
Skip dependency update suggestions that a toolchain peer range does not allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,18 @@ Example:
 `npx @iobroker/repochecker https://github.com/ioBroker/ioBroker.repochecker --local`
 
 ## Changelog
-
 <!--
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
-
 ### **WORK IN PROGRESS**
 
 * (krobipd) Skip dependency update suggestions when the newer version would violate a peer dependency range declared by the adapter's toolchain, e.g. suggesting `typescript` 7 while `typescript-eslint` (pulled in by `@iobroker/eslint-config`) requires `<6.1.0`.
 
 ### 5.20.1 (2026-07-17)
 
-- (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.
-- (Copilot) Warn when tracked files or directories are still covered by `.gitignore` and error if a tracked `/build` directory is ignored.
+* (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.
+* (Copilot) Warn when tracked files or directories are still covered by `.gitignore` and error if a tracked `/build` directory is ignored.
 
 ### 5.19.12 (2026-07-13)
 
@@ -87,72 +85,72 @@ Example:
 
 ### 5.19.1 (2026-06-28)
 
-- (mcm1957) checking of untranslated i18n keys has been adapted
+-  (mcm1957) checking of untranslated i18n keys has been adapted
 
 ### 5.19.0 (2026-06-27)
 
-- (mcm1957) github install detection has been enhanced
-- (mcm1957) checking of untranslated i18n keys has been enhanced
-- (mcm1957) disallow npm installation scripts
+-  (mcm1957) github install detection has been enhanced
+-  (mcm1957) checking of untranslated i18n keys has been enhanced
+-  (mcm1957) disallow npm installation scripts
 
 ### 5.18.11 (2026-06-24)
 
-- (mcm1957) blacklisting for dependency versionchecking checking added
-- (mcm1957) handling of i18n attirbute at jsonConfig has been adapted
+-  (mcm1957) blacklisting for dependency versionchecking checking added
+-  (mcm1957) handling of i18n attirbute at jsonConfig has been adapted
 
 ### 5.18.10 (2026-06-23)
 
-- (mcm1957) some more directories have been excluded from dependency scan
+-  (mcm1957) some more directories have been excluded from dependency scan
 
 ### 5.18.9 (2026-06-22)
 
-- (mcm1957) eslint-config import check has been adapted
-- (mcm1957) EXCEPTION: exceptions added flase positive apiKey paramaters
+-  (mcm1957) eslint-config import check has been adapted
+-  (mcm1957) EXCEPTION: exceptions added flase positive apiKey paramaters
 
 ### 5.18.8 (2026-06-21)
 
-- (mcm1957) Sentry text check has been adapted
-- (mcm1957) Fixed validation of serialized default values for array, object, mixed, json, and file states
+-  (mcm1957) Sentry text check has been adapted
+-  (mcm1957) Fixed validation of serialized default values for array, object, mixed, json, and file states
 
 ### 5.18.7 (2026-06-10)
 
-- (mcm1957) Detection of github install guide extended
+-  (mcm1957) Detection of github install guide extended
 
 ### 5.18.6 (2026-06-10)
 
-- (mcm1957) Support role definitions containing wildcards
-- (mcm1957) Support header 'Older versions' within changelog
+-  (mcm1957) Support role definitions containing wildcards
+-  (mcm1957) Support header 'Older versions' within changelog
 
 ### 5.18.5 (2026-06-09)
 
-- (mcm1957) mode.\* roles fixed
-- (mcm1957) build directory excluded from I18n scans
-- (mcm1957) Handling of alpha releasea at changelog corrected
-- (mcm1957) Changing text for missing updates limited to 50 days
-- (mcm1957) Encrypted / protected UI data depuplicated
-- (mcm1957) Scanning for sourcefiles and imports corrected
-- (mcm1957) Special filtering added
+-  (mcm1957) mode.* roles fixed
+-  (mcm1957) build directory excluded from I18n scans
+-  (mcm1957) Handling of alpha releasea at changelog corrected
+-  (mcm1957) Changing text for missing updates limited to 50 days
+-  (mcm1957) Encrypted / protected UI data depuplicated
+-  (mcm1957) Scanning for sourcefiles and imports corrected
+-  (mcm1957) Special filtering added
 
 ### 5.18.3 (2026-06-06)
 
-- (mcm1957) Support for objectStructure check added
+-  (mcm1957) Support for objectStructure check added
 
 ### 5.17.9 (2026-06-04)
 
-- (mcm1957) Require release-script 5.2.1.
-- (mcm1957) Searching for release tag workflow has been fixed.
+-  (mcm1957) Require release-script 5.2.1.
+-  (mcm1957) Searching for release tag workflow has been fixed.
 
 ### 5.17.6 (2026-06-03)
 
-- (mcm1957) Severities have been adapted.
+-  (mcm1957) Severities have been adapted.
 
 ### 5.17.5 (2026-06-02)
 
-- (mcm1957) Minor checkings at README formatting have been done.
+-  (mcm1957) Minor checkings at README formatting have been done.
 
 ### 5.17.4 (2026-05-31)
 
-- (mcm1957) default value for engines corrected.
+-  (mcm1957) default value for engines corrected.
 
 ### 5.17.3 (2026-05-30)
 
@@ -245,7 +243,6 @@ Example:
 - (@copilot) Added `[W5052]`/`[W5053]`: when jsonConfig is used, password fields found in `admin/*.json` and `admin/*.json5` (outside table components) are now checked against `protectedNative` and `encryptedNative` in `io-package.json`.
 
 ### 5.12.1 (2026-05-20)
-
 - (mcm197) cleanup some duplicate numbers
 
 ### 5.12.0 (2026-05-20)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (krobipd) Skip dependency update suggestions when the newer version would violate a peer dependency range declared by the adapter's toolchain, e.g. suggesting `typescript` 7 while `typescript-eslint` (pulled in by `@iobroker/eslint-config`) requires `<6.1.0`.
+
 ### 5.20.1 (2026-07-17)
 
 * (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.

--- a/README.md
+++ b/README.md
@@ -27,18 +27,20 @@ Example:
 `npx @iobroker/repochecker https://github.com/ioBroker/ioBroker.repochecker --local`
 
 ## Changelog
+
 <!--
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+
 ### **WORK IN PROGRESS**
 
 * (krobipd) Skip dependency update suggestions when the newer version would violate a peer dependency range declared by the adapter's toolchain, e.g. suggesting `typescript` 7 while `typescript-eslint` (pulled in by `@iobroker/eslint-config`) requires `<6.1.0`.
 
 ### 5.20.1 (2026-07-17)
 
-* (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.
-* (Copilot) Warn when tracked files or directories are still covered by `.gitignore` and error if a tracked `/build` directory is ignored.
+- (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.
+- (Copilot) Warn when tracked files or directories are still covered by `.gitignore` and error if a tracked `/build` directory is ignored.
 
 ### 5.19.12 (2026-07-13)
 
@@ -85,72 +87,72 @@ Example:
 
 ### 5.19.1 (2026-06-28)
 
--  (mcm1957) checking of untranslated i18n keys has been adapted
+- (mcm1957) checking of untranslated i18n keys has been adapted
 
 ### 5.19.0 (2026-06-27)
 
--  (mcm1957) github install detection has been enhanced
--  (mcm1957) checking of untranslated i18n keys has been enhanced
--  (mcm1957) disallow npm installation scripts
+- (mcm1957) github install detection has been enhanced
+- (mcm1957) checking of untranslated i18n keys has been enhanced
+- (mcm1957) disallow npm installation scripts
 
 ### 5.18.11 (2026-06-24)
 
--  (mcm1957) blacklisting for dependency versionchecking checking added
--  (mcm1957) handling of i18n attirbute at jsonConfig has been adapted
+- (mcm1957) blacklisting for dependency versionchecking checking added
+- (mcm1957) handling of i18n attirbute at jsonConfig has been adapted
 
 ### 5.18.10 (2026-06-23)
 
--  (mcm1957) some more directories have been excluded from dependency scan
+- (mcm1957) some more directories have been excluded from dependency scan
 
 ### 5.18.9 (2026-06-22)
 
--  (mcm1957) eslint-config import check has been adapted
--  (mcm1957) EXCEPTION: exceptions added flase positive apiKey paramaters
+- (mcm1957) eslint-config import check has been adapted
+- (mcm1957) EXCEPTION: exceptions added flase positive apiKey paramaters
 
 ### 5.18.8 (2026-06-21)
 
--  (mcm1957) Sentry text check has been adapted
--  (mcm1957) Fixed validation of serialized default values for array, object, mixed, json, and file states
+- (mcm1957) Sentry text check has been adapted
+- (mcm1957) Fixed validation of serialized default values for array, object, mixed, json, and file states
 
 ### 5.18.7 (2026-06-10)
 
--  (mcm1957) Detection of github install guide extended
+- (mcm1957) Detection of github install guide extended
 
 ### 5.18.6 (2026-06-10)
 
--  (mcm1957) Support role definitions containing wildcards
--  (mcm1957) Support header 'Older versions' within changelog
+- (mcm1957) Support role definitions containing wildcards
+- (mcm1957) Support header 'Older versions' within changelog
 
 ### 5.18.5 (2026-06-09)
 
--  (mcm1957) mode.* roles fixed
--  (mcm1957) build directory excluded from I18n scans
--  (mcm1957) Handling of alpha releasea at changelog corrected
--  (mcm1957) Changing text for missing updates limited to 50 days
--  (mcm1957) Encrypted / protected UI data depuplicated
--  (mcm1957) Scanning for sourcefiles and imports corrected
--  (mcm1957) Special filtering added
+- (mcm1957) mode.\* roles fixed
+- (mcm1957) build directory excluded from I18n scans
+- (mcm1957) Handling of alpha releasea at changelog corrected
+- (mcm1957) Changing text for missing updates limited to 50 days
+- (mcm1957) Encrypted / protected UI data depuplicated
+- (mcm1957) Scanning for sourcefiles and imports corrected
+- (mcm1957) Special filtering added
 
 ### 5.18.3 (2026-06-06)
 
--  (mcm1957) Support for objectStructure check added
+- (mcm1957) Support for objectStructure check added
 
 ### 5.17.9 (2026-06-04)
 
--  (mcm1957) Require release-script 5.2.1.
--  (mcm1957) Searching for release tag workflow has been fixed.
+- (mcm1957) Require release-script 5.2.1.
+- (mcm1957) Searching for release tag workflow has been fixed.
 
 ### 5.17.6 (2026-06-03)
 
--  (mcm1957) Severities have been adapted.
+- (mcm1957) Severities have been adapted.
 
 ### 5.17.5 (2026-06-02)
 
--  (mcm1957) Minor checkings at README formatting have been done.
+- (mcm1957) Minor checkings at README formatting have been done.
 
 ### 5.17.4 (2026-05-31)
 
--  (mcm1957) default value for engines corrected.
+- (mcm1957) default value for engines corrected.
 
 ### 5.17.3 (2026-05-30)
 
@@ -243,6 +245,7 @@ Example:
 - (@copilot) Added `[W5052]`/`[W5053]`: when jsonConfig is used, password fields found in `admin/*.json` and `admin/*.json5` (outside table components) are now checked against `protectedNative` and `encryptedNative` in `io-package.json`.
 
 ### 5.12.1 (2026-05-20)
+
 - (mcm197) cleanup some duplicate numbers
 
 ### 5.12.0 (2026-05-20)

--- a/lib/M0000_PackageJson.js
+++ b/lib/M0000_PackageJson.js
@@ -490,6 +490,126 @@ function getNpmUpdateRule(context, packageName) {
     return { minimumAgeDays, level };
 }
 
+// npm manifests fetched while looking for peer constraints. One entry per package
+// name, reused for the whole run so a repeated lookup costs nothing.
+const npmManifestCache = new Map();
+
+/**
+ * Fetches the full npm manifest of a package. Returns null if it cannot be read,
+ * so callers can simply skip that package instead of aborting the whole check.
+ *
+ * @param {string} packageName - npm package name
+ * @returns {Promise<object|null>} npm manifest or null
+ */
+async function fetchNpmManifest(packageName) {
+    if (npmManifestCache.has(packageName)) {
+        return npmManifestCache.get(packageName);
+    }
+    try {
+        const response = await axios(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`);
+        npmManifestCache.set(packageName, response.data);
+        return response.data;
+    } catch (e) {
+        common.debug(`Could not fetch npm manifest for "${packageName}": ${e.message || e}`);
+        npmManifestCache.set(packageName, null);
+        return null;
+    }
+}
+
+/**
+ * Picks the highest published version of a package that satisfies the declared range.
+ * That is the version an adapter actually installs, so its peer constraints are the
+ * ones that matter.
+ *
+ * @param {object} manifest - npm manifest of the package
+ * @param {string} range - version range as declared in package.json
+ * @returns {string|null} resolved version or null
+ */
+function resolveVersionFromRange(manifest, range) {
+    const available = Object.keys(manifest?.versions || {});
+    if (!available.length) {
+        return null;
+    }
+    if (!semver.validRange(range)) {
+        return manifest?.['dist-tags']?.latest || null;
+    }
+    return semver.maxSatisfying(available, range) || manifest?.['dist-tags']?.latest || null;
+}
+
+/**
+ * Checks whether upgrading a package would violate a peer dependency constraint
+ * declared somewhere in the adapter's own toolchain.
+ *
+ * Background: `@iobroker/eslint-config` — which this checker recommends via S0071/S0073 —
+ * depends on `typescript-eslint`, and that declares a peer range of `typescript >=4.8.4 <6.1.0`.
+ * Without this check an adapter on typescript@6 is asked to upgrade to typescript@7, which
+ * would break the very ESLint setup the checker asks for. The suggestion cannot be acted on.
+ *
+ * Two levels are inspected: the declared dependencies themselves, and the packages they
+ * pull in (peer constraints usually sit one level down, as in the example above). This runs
+ * only when a suggestion is about to be raised — typically for a handful of packages per
+ * run — and all manifests are cached, so the extra registry lookups stay modest.
+ *
+ * @param {object} context - The checker context
+ * @param {string} packageName - npm package the suggestion would be about
+ * @param {string} newVersion - version that would be suggested
+ * @returns {Promise<string|null>} name of the package whose peer range blocks the upgrade, or null
+ */
+async function findPeerConstraintBlockingUpgrade(context, packageName, newVersion) {
+    const declaredDependencies = {
+        ...(context.packageJson.dependencies || {}),
+        ...(context.packageJson.devDependencies || {}),
+    };
+
+    for (const [declaredName, declaredRange] of Object.entries(declaredDependencies)) {
+        if (declaredName === packageName) {
+            continue;
+        }
+
+        const parsed = parseDependencyDeclaration(declaredName, declaredRange);
+        const manifest = await fetchNpmManifest(parsed.packageName);
+        if (!manifest) {
+            continue;
+        }
+        const resolvedVersion = resolveVersionFromRange(manifest, parsed.packageVersion);
+        const versionManifest = resolvedVersion ? manifest.versions?.[resolvedVersion] : null;
+        if (!versionManifest) {
+            continue;
+        }
+
+        const directPeerRange = versionManifest.peerDependencies?.[packageName];
+        if (directPeerRange && !semver.satisfies(newVersion, directPeerRange, { includePrerelease: true })) {
+            return parsed.packageName;
+        }
+
+        // Peer constraints are commonly declared by a package the adapter installs only
+        // indirectly, so look one level deeper. Both dependency kinds have to be followed:
+        // `@iobroker/eslint-config` for example lists `typescript-eslint` as a PEER, and it
+        // is that package which pins the typescript range.
+        const nestedDependencies = {
+            ...(versionManifest.dependencies || {}),
+            ...(versionManifest.peerDependencies || {}),
+        };
+        for (const [nestedName, nestedRange] of Object.entries(nestedDependencies)) {
+            if (nestedName === packageName) {
+                continue;
+            }
+            const nestedManifest = await fetchNpmManifest(nestedName);
+            if (!nestedManifest) {
+                continue;
+            }
+            const nestedVersion = resolveVersionFromRange(nestedManifest, nestedRange);
+            const nestedVersionManifest = nestedVersion ? nestedManifest.versions?.[nestedVersion] : null;
+            const nestedPeerRange = nestedVersionManifest?.peerDependencies?.[packageName];
+            if (nestedPeerRange && !semver.satisfies(newVersion, nestedPeerRange, { includePrerelease: true })) {
+                return nestedName;
+            }
+        }
+    }
+
+    return null;
+}
+
 /**
  * Checks if dependencies/devDependencies should receive update suggestions based on npm publish age.
  *
@@ -581,6 +701,21 @@ async function checkNpmDependencyUpdateSuggestions(context) {
                     const packageAgeDays = Math.floor((now - publishedAtDate.getTime()) / millisecondsPerDay);
                     const updateRule = getNpmUpdateRule(context, packageName);
                     if (packageAgeDays < updateRule.minimumAgeDays) {
+                        return;
+                    }
+
+                    // Skip suggestions the adapter cannot follow: a newer version that
+                    // violates a peer range declared by its own toolchain would break the
+                    // setup this checker asks for elsewhere.
+                    const blockingPackage = await findPeerConstraintBlockingUpgrade(
+                        context,
+                        packageName,
+                        latestVersion,
+                    );
+                    if (blockingPackage) {
+                        common.debug(
+                            `    skipping update suggestion for ${packageName}@${latestVersion} — peer constraint of ${blockingPackage} does not allow it`,
+                        );
                         return;
                     }
 


### PR DESCRIPTION
W0083/S0082 currently compares each dependency against `dist-tags.latest` without checking whether the newer version fits the peer ranges of the packages an adapter already uses. When it does not fit, the suggestion cannot be acted on.

### Example

`@iobroker/eslint-config` lists `typescript-eslint` as a peer dependency, and that package declares `typescript >=4.8.4 <6.1.0`. An adapter using `typescript@~6.0.3` therefore receives:

```
[W0083] A newer version (7.0.2) for package "typescript" (devDependencies) exists.
        Please evaluate if upgrading from 6.0.3 to 7.0.2 is possible.
```

Upgrading would break the ESLint setup that S0071/S0073 recommend a few lines further down in the same check function. For reference, the official ioBroker TypeScript adapter template currently ships `typescript: ~5.9.3`.

### Change

Before a suggestion is raised, the declared dependencies and the packages they pull in are inspected for a peer range on the package in question. If the newer version does not satisfy it, the suggestion is skipped and the reason is written to the debug log.

Both `dependencies` and `peerDependencies` are followed one level down, because the constraint often sits there rather than in the directly declared package — as in the example above. Manifests are cached per run and only fetched when a suggestion is actually pending, so the additional registry traffic stays small.

This follows the same reasoning that already excludes `@types/node` in `npmUpdateSuggestions.blacklistedPackages` (tied to the Node.js baseline) — with the difference that resolving the constraint keeps the check active: as soon as `typescript-eslint` widens its range, the suggestion appears again on its own.

### Verified

- `krobipd/ioBroker.nut2` — the typescript suggestion is gone, the other seven findings are unchanged
- `krobipd/ioBroker.govee-smart` — output identical to the unpatched checker

Related to #1080.