### PR TITLE
Detect React usage via @iobroker/gui-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (mcm1957) React usage is now also detected when `@iobroker/gui-components` is used as dependency.
+
 ### 5.20.1 (2026-07-17)
 
 * (Copilot) Add a workflow check that rejects `always()` on standard test-and-release jobs and flags it for review on custom jobs.

--- a/lib/M5000_Code.js
+++ b/lib/M5000_Code.js
@@ -849,6 +849,7 @@ async function checkCode(context) {
     if (
         context.packageJson.devDependencies &&
         (context.packageJson.devDependencies['@iobroker/adapter-react-v5'] ||
+            context.packageJson.devDependencies['@iobroker/gui-components'] ||
             context.packageJson.devDependencies['react'])
     ) {
         common.info('REACT detected at package devDependencies');
@@ -856,18 +857,28 @@ async function checkCode(context) {
     }
     if (
         context.packageJson.dependencies &&
-        (context.packageJson.dependencies['@iobroker/adapter-react-v5'] || context.packageJson.dependencies['react'])
+        (context.packageJson.dependencies['@iobroker/adapter-react-v5'] ||
+            context.packageJson.dependencies['@iobroker/gui-components'] ||
+            context.packageJson.dependencies['react'])
     ) {
         common.info('REACT detected at package dependencies');
         usesReact = true;
     }
     if (context['/src-admin/package.json']) {
         const packageJson = JSON.parse(context['/src-admin/package.json']);
-        if (packageJson.devDependencies && packageJson.devDependencies['@iobroker/adapter-react-v5']) {
+        if (
+            packageJson.devDependencies &&
+            (packageJson.devDependencies['@iobroker/adapter-react-v5'] ||
+                packageJson.devDependencies['@iobroker/gui-components'])
+        ) {
             common.info('REACT detected at src-admin/package devDependencies');
             usesReact = true;
         }
-        if (packageJson.dependencies && packageJson.dependencies['@iobroker/adapter-react-v5']) {
+        if (
+            packageJson.dependencies &&
+            (packageJson.dependencies['@iobroker/adapter-react-v5'] ||
+                packageJson.dependencies['@iobroker/gui-components'])
+        ) {
             common.info('REACT detected at src-admin/package dependencies');
             usesReact = true;
         }
@@ -876,14 +887,18 @@ async function checkCode(context) {
         const packageJson = JSON.parse(context['/src-widgets/package.json']);
         if (
             packageJson.devDependencies &&
-            (packageJson.devDependencies['@iobroker/adapter-react-v5'] || packageJson.devDependencies['react'])
+            (packageJson.devDependencies['@iobroker/adapter-react-v5'] ||
+                packageJson.devDependencies['@iobroker/gui-components'] ||
+                packageJson.devDependencies['react'])
         ) {
             common.info('REACT detected at src-widgets/package devDependencies');
             usesReact = true;
         }
         if (
             packageJson.dependencies &&
-            (packageJson.dependencies['@iobroker/adapter-react-v5'] || packageJson.dependencies['react'])
+            (packageJson.dependencies['@iobroker/adapter-react-v5'] ||
+                packageJson.dependencies['@iobroker/gui-components'] ||
+                packageJson.dependencies['react'])
         ) {
             common.info('REACT detected at src-widgets/package dependencies');
             usesReact = true;
@@ -892,11 +907,19 @@ async function checkCode(context) {
     if (context['/src/package.json']) {
         //console.log('"src/package.json" exists');
         const packageJson = JSON.parse(context['/src/package.json']);
-        if (packageJson.devDependencies && packageJson.devDependencies['@iobroker/adapter-react-v5']) {
+        if (
+            packageJson.devDependencies &&
+            (packageJson.devDependencies['@iobroker/adapter-react-v5'] ||
+                packageJson.devDependencies['@iobroker/gui-components'])
+        ) {
             // console.log('REACT detected');
             usesReact = true;
         }
-        if (packageJson.dependencies && packageJson.dependencies['@iobroker/adapter-react-v5']) {
+        if (
+            packageJson.dependencies &&
+            (packageJson.dependencies['@iobroker/adapter-react-v5'] ||
+                packageJson.dependencies['@iobroker/gui-components'])
+        ) {
             // console.log('REACT detected');
             usesReact = true;
         }


### PR DESCRIPTION
## What changed

Extended the React-detection logic in `lib/M5000_Code.js` so that a dependency on `@iobroker/gui-components` sets `usesReact = true`, exactly as `@iobroker/adapter-react-v5` already does. This is applied across all checked package.json locations: root, `/src-admin`, `/src-widgets`, and `/src`.

## Why

Adapters using `@iobroker/gui-components` are React-based, but were previously not recognized as such, which could lead to incorrect checks/warnings for those adapters.

## Notes for reviewers

- Minimal changes only — each existing `@iobroker/adapter-react-v5` check now also accepts `@iobroker/gui-components`; the `react` fallback is preserved where it existed.
- Changelog entry added to `README.md` under **WORK IN PROGRESS**.