### PR TITLE
Fix E6012/E6013 not raised for install commands inside code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (mcm1957) Fixed `[E6012]`/`[E6013]` not being raised when direct install commands (e.g. `npm install` or `cd /opt/iobroker`) are placed inside fenced code blocks in README.md.
+
 ### 5.20.3 (2026-08-07)
 
 * (mcm1957) Fixed false positive `[S9508]` (and related packaging/i18n checks): negation entries (e.g. `!CHANGELOG_OLD.md`) in package.json `"files"` are now handled as exclusions instead of being wrongly matched. Related to #1097 and #1072.

--- a/lib/M6000_Readme.js
+++ b/lib/M6000_Readme.js
@@ -240,18 +240,21 @@ function stripMarkdownForLanguageDetection(text) {
 
 /**
  * Strip markdown inline formatting for install-instruction text scanning.
- * Removes fenced/inline code blocks, expands links to "text URL" so that URL
- * checks still work, and removes bold/italic emphasis markers so that formatted
- * text like `install from **[GitHub](url)**` is still detected.
+ * Keeps the content of fenced/inline code (install commands like `npm install`
+ * or `cd /opt/iobroker` are normally placed inside ``` fences and must still be
+ * detected), expands links to "text URL" so that URL checks still work, and
+ * removes bold/italic emphasis markers so that formatted text like
+ * `install from **[GitHub](url)**` is still detected.
  *
  * @param {string} text - Raw markdown text
  * @returns {string} Text with inline formatting stripped
  */
 function stripMarkdownInlineFormatting(text) {
-    // Remove fenced code blocks (``` ... ```)
-    text = text.replace(/```[\s\S]*?```/g, '');
-    // Remove inline code (`...`)
-    text = text.replace(/`[^`\n]*`/g, '');
+    // Remove fenced code block delimiter lines (``` and ```lang) but KEEP the
+    // enclosed content so shell install commands remain scannable.
+    text = text.replace(/^[ \t]*```[^\n]*$/gm, '');
+    // Remove inline code backticks but keep the content
+    text = text.replace(/`/g, '');
     // Expand links [text](url) -> "text url" (preserve both visible text and URL for checks)
     text = text.replace(/\[([^\]]*)\]\(([^)]*)\)/g, '$1 $2');
     // Remove bold+italic (***) and bold (**) markers


### PR DESCRIPTION
## What changed

`stripMarkdownInlineFormatting()` in `lib/M6000_Readme.js` previously deleted fenced code blocks entirely (```` ```[\s\S]*?``` ````) before the install-instruction checks ran. It now strips only the fence delimiter lines and keeps the enclosed content.

## Why

The E6012/E6013 checks scan the text returned by `stripMarkdownInlineFormatting()`. Since direct install commands (`npm install`, `cd /opt/iobroker`) are normally placed **inside** ```` ```bash ```` fences, they were stripped away and never detected.

Example that slipped through — [ioBroker.zeptrion README](https://github.com/bueste/ioBroker.zeptrion/blob/main/README.md#a-localmanual-before-store-publication):

```bash
cd /opt/iobroker/node_modules
mkdir iobroker.zeptrion
cd iobroker.zeptrion
npm install --production
```

With this fix the `cd /opt/iobroker` line is detected and **E6012** is correctly raised.

## Reviewer notes

- `stripMarkdownInlineFormatting()` has a single call site (the install checks), so language detection (which uses the separate `stripMarkdownForLanguageDetection()`) is unaffected.
- E6012's `npm install iobroker.*` pattern still won't match a bare `npm install --production` (no adapter name), but the `cd /opt/iobroker` pattern covers this case.
- Changelog entry added under **WORK IN PROGRESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)