### PR TITLE
Extend E9507 i18n check with src-tab and src-vis exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (mcm1957) Extended `[E9507]` i18n directory check to also exclude `src-tab` and `src-vis` source directories from packaging checks.
+
 ### 5.20.4 (2026-08-08)
 
 * (mcm1957) Fixed `[E6012]`/`[E6013]` not being raised when direct install commands (e.g. `npm install` or `cd /opt/iobroker`) are placed inside fenced code blocks in README.md.

--- a/lib/M9000_GitNpmIgnore.js
+++ b/lib/M9000_GitNpmIgnore.js
@@ -25,8 +25,10 @@ const { minimatch } = require('minimatch');
 const SRC_DIRS_TO_IGNORE = [
     'src',
     'src-admin',
-    'src-editor',
+    'src-editor', // java-script adapter
     'src-rules',
+    'src-tab',
+    'src-vis',
     'src-widgets',
     'admin-src',
     'rules-src',


### PR DESCRIPTION
## Summary
Extends the `SRC_DIRS_TO_IGNORE` list used by the i18n directory checks (`[E9507]` / `[E9506]`) in `M9000_GitNpmIgnore.js` so that i18n directories inside additional build-source folders are correctly excluded from packaging checks.

- Added `src-tab` and `src-vis` (were missing)
- Added `// java-script adapter` comment to `src-editor`

Existing entries (`src`, `src-admin`, `src-editor`, `src-rules`, `src-widgets`, `admin-src`, `rules-src`, `admin/src`) were already present and are unchanged.

## Notes
Entries use the no-leading-slash format required by the existing root-anchored matching logic (parent path has its leading slash stripped before comparison).

## Changelog
Added a `**WORK IN PROGRESS**` entry to README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)