### PR TITLE
Fix multi-level source directory exclusion in code scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (mcm1957) Fixed source directory exclusion so multi-level paths (e.g. `src/lib/scripts`, `src/scripts`) are correctly skipped during code scanning, avoiding false positives such as `[S5051]`.
+
 ### 5.20.7 (2026-08-09)
 
 * (mcm1957) Exclude directories 'example(s)' from processing

--- a/lib/M5000_Code.js
+++ b/lib/M5000_Code.js
@@ -1850,13 +1850,15 @@ async function checkCode(context) {
         '/hass_frontend', // special for ioBroker.hass
         'tmp',
     ]);
-    const excludedSourceRootDirNames = new Set();
+    // Rooted entries ('/foo' or '/foo/bar') are matched as path prefixes relative to the repo
+    // root, so multi-level paths like '/src/lib/scripts' are honored and not just their first segment.
+    const excludedSourceRootPaths = new Set();
     const excludedSourceAnyLevelDirs = new Set();
     for (const excludedSourceDir of excludedSourceDirs) {
         if (excludedSourceDir.startsWith('/')) {
-            const rootDirName = excludedSourceDir.slice(1);
-            if (rootDirName) {
-                excludedSourceRootDirNames.add(rootDirName);
+            const rootPath = excludedSourceDir.slice(1);
+            if (rootPath) {
+                excludedSourceRootPaths.add(rootPath);
             }
         } else {
             excludedSourceAnyLevelDirs.add(excludedSourceDir);
@@ -1916,7 +1918,10 @@ async function checkCode(context) {
 
         // Skip files in excluded directories
         const pathParts = filePath.split('/').filter(p => p !== '');
-        const isInExcludedSourceRootDir = pathParts.length > 0 && excludedSourceRootDirNames.has(pathParts[0]);
+        const relFilePath = pathParts.join('/'); // path relative to repo root, e.g. "src/lib/scripts/36-grafana.ts"
+        const isInExcludedSourceRootDir = [...excludedSourceRootPaths].some(
+            rootPath => relFilePath === rootPath || relFilePath.startsWith(`${rootPath}/`),
+        );
         const isInExcludedSourceAnyLevelDir = pathParts.some(pathPart => excludedSourceAnyLevelDirs.has(pathPart));
         const isInExcludedSourceDir = isInExcludedSourceRootDir || isInExcludedSourceAnyLevelDir;
         if (isInExcludedSourceDir) {


### PR DESCRIPTION
## What changed

The M5000 code scanner skips files inside excluded directories using a list that includes multi-level rooted paths like `/src/lib/scripts` and `/src/scripts`. The matching logic, however, only compared the **first** path segment of each file against the excluded entries, so any rooted entry deeper than one level never matched.

- Parsing stored `/src/lib/scripts` as the string `"src/lib/scripts"`.
- Matching did `excludedSourceRootDirNames.has(pathParts[0])`, comparing only `"src"` → always `false`.

This PR changes rooted exclusion entries to be matched as **path prefixes** relative to the repo root (`relFilePath === rootPath || relFilePath.startsWith(rootPath + '/')`). Single-segment entries such as `/admin`, `/build` continue to work unchanged.

## Why

Files under `src/lib/scripts/` (and similar) were scanned despite being listed as excluded, producing false positives such as:

```
[S5051] Custom sleep/wait function(s) found in source files (src/lib/scripts/36-grafana.ts, src/lib/scripts/42-javascripts.ts).
```

## Notes for reviewers

- Change is isolated to `lib/M5000_Code.js` (exclusion parsing + matching) plus a README changelog entry.
- No automated test suite exists in this repo; the fix was verified by reasoning through the affected path cases. Only the multi-level rooted entries (`/src/lib/scripts`, `/src/scripts`) were previously broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)