### PR TITLE
Detect matrix-controlled check-and-lint workflow jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (mcm1957) The "check-and-lint" workflow job is now also detected when controlled by a matrix (job names starting with "check-and-lint (").
+
 ### 5.20.9 (2026-08-10)
 
 * (mcm1957) Added new state roles for air quality and environmental sensors (`value.co`, `value.no`, `value.no2`, `value.o3`, `value.ch2o`, `value.pm1`, `value.pm25`, `value.pm10`, `value.rn`, `value.tvoc`, `value.airquality`, `value.humidity.relative`, `value.humidity.absolute`) and defined type/read/write constraints for `value.temperature.dewpoint`.

--- a/lib/M3000_Testing.js
+++ b/lib/M3000_Testing.js
@@ -218,7 +218,9 @@ async function checkTagTriggeredRun(context, workflowRuns, version, taggedVersio
             const runJobs = await fetchRunJobs(context, tagRun.id);
 
             // W3050 / S3051: check-and-lint job log
-            const checkAndLintJob = runJobs.find(job => job.name === 'check-and-lint');
+            const checkAndLintJob = runJobs.find(
+                job => job.name === 'check-and-lint' || job.name.startsWith('check-and-lint ('),
+            );
             if (!checkAndLintJob) {
                 context.warnings.push(
                     `[W3050] "${WORKFLOW_FILE_SHORT}": no "check-and-lint" job found in ${formatRunLink(tagRun)} for ${sourceLabel}. ` +
@@ -1022,7 +1024,9 @@ async function checkTests(context) {
                     const runJobs = await fetchRunJobs(context, lastRun.id);
 
                     // W3050 / S3051: check-and-lint job log
-                    const checkAndLintJob = runJobs.find(job => job.name === 'check-and-lint');
+                    const checkAndLintJob = runJobs.find(
+                        job => job.name === 'check-and-lint' || job.name.startsWith('check-and-lint ('),
+                    );
                     if (!checkAndLintJob) {
                         context.warnings.push(
                             `[W3050] "${WORKFLOW_FILE_SHORT}": no "check-and-lint" job found in ${formatRunLink(lastRun)} on branch "${defaultBranch}". ` +


### PR DESCRIPTION
## Summary

`M3000_Testing` matched the `check-and-lint` job by its exact name only, so jobs controlled by a matrix (e.g. `check-and-lint (18.x)`) were reported as missing. The `adapter-tests` check already handled this via a `startsWith('adapter-tests (')` prefix match.

This aligns the `check-and-lint` job lookups (both the tag-run and default-branch code paths) with that pattern, matching either the exact name `check-and-lint` or names starting with `check-and-lint (`.

## Changes

- `lib/M3000_Testing.js`: prefix-match matrix-controlled `check-and-lint` jobs in both run-log checks.
- `README.md`: changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)